### PR TITLE
fixed: "compiled-firmware" folder missing under linux

### DIFF
--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 docker build -t uvk5 .
-docker run -v $(PWD)/compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware* compiled-firmware/"
+docker run -v ${PWD}/compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware* compiled-firmware/"


### PR DESCRIPTION
fixed: "compiled-firmware" folder missing under linux - fixed shell variable $PWD

Syntax '$(PWD)' is incorrect, cause '$()' is a specific syntaxt for executing shell command, e.g. 'pwd'.
So we have two options:
1) '$(pwd)' - execute  pwd program
2) '$PWD' ( or better '${PWD}' ) - get the PWD variable from the shell