### PR TITLE
feat: change VFO A/B using exit key - ported from fagci-mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ firmware
 /firmware.packed.bin
 /firmware.bin
 /compiled-firmware
+*.kate-swp


### PR DESCRIPTION
My change suggestion: the Exit key could be used to switch the active VFO between A and B, same as F+2, but more convenient