### PR TITLE
 Add "BLMIN TMP OFF" function for programmable buttons

### DIFF
--- a/app/action.c
+++ b/app/action.c
@@ -31,6 +31,7 @@
 #endif
 #include "driver/bk4819.h"
 #include "driver/gpio.h"
+#include "driver/backlight.h"
 #include "functions.h"
 #include "misc.h"
 #include "settings.h"
@@ -332,6 +333,18 @@ void ACTION_SwitchDemodul(void)
 	gRequestSaveChannel = 1;
 }
 
+void ACTION_BlminTmpOff(void)
+{
+	if(++gEeprom.BACKLIGHT_MIN_STAT == BLMIN_STAT_UNKNOWN)
+	{
+		gEeprom.BACKLIGHT_MIN_STAT = BLMIN_STAT_ON;
+		BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MIN);
+	} else
+	{
+		BACKLIGHT_SetBrightness(0);
+	}
+}
+
 void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 {
 	if (gScreenToDisplay == DISPLAY_MAIN && gDTMF_InputMode) // entering DTMF code
@@ -449,6 +462,9 @@ void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 			break;
 		case ACTION_OPT_SWITCH_DEMODUL:
 			ACTION_SwitchDemodul();
-			break;	
+			break;
+		case ACTION_OPT_BLMIN_TMP_OFF:
+			ACTION_BlminTmpOff();
+			break;
 	}
 }

--- a/app/action.h
+++ b/app/action.h
@@ -33,6 +33,7 @@ void ACTION_Scan(bool bRestart);
 	void ACTION_FM(void);
 #endif
 void ACTION_SwitchDemodul(void);
+void ACTION_BlminTmpOff(void);
 
 void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld);
 

--- a/board.c
+++ b/board.c
@@ -537,6 +537,7 @@ void BOARD_EEPROM_Init(void)
 	EEPROM_ReadBuffer(0x0E78, Data, 8);
 	gEeprom.BACKLIGHT_MAX 		  = (Data[0] & 0xF) <= 10 ? (Data[0] & 0xF) : 10;
 	gEeprom.BACKLIGHT_MIN 		  = (Data[0] >> 4) < gEeprom.BACKLIGHT_MAX ? (Data[0] >> 4) : 0;
+	gEeprom.BACKLIGHT_MIN_STAT	  = BLMIN_STAT_ON;
 	gEeprom.CHANNEL_DISPLAY_MODE  = (Data[1] < 4) ? Data[1] : MDF_FREQUENCY;    // 4 instead of 3 - extra display mode
 	gEeprom.CROSS_BAND_RX_TX      = (Data[2] < 3) ? Data[2] : CROSS_BAND_OFF;
 	gEeprom.BATTERY_SAVE          = (Data[3] < 5) ? Data[3] : 4;

--- a/driver/backlight.c
+++ b/driver/backlight.c
@@ -94,7 +94,14 @@ void BACKLIGHT_TurnOn(void)
 
 void BACKLIGHT_TurnOff()
 {
-	BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MIN);
+	register uint8_t tmp;
+
+	if (gEeprom.BACKLIGHT_MIN_STAT == BLMIN_STAT_ON)
+		tmp = gEeprom.BACKLIGHT_MIN;
+	else
+		tmp = 0;
+
+	BACKLIGHT_SetBrightness(tmp);
 	gBacklightCountdown = 0;
 	backlightOn = false;
 }

--- a/driver/backlight.h
+++ b/driver/backlight.h
@@ -23,6 +23,12 @@
 extern uint16_t gBacklightCountdown;
 extern uint8_t gBacklightBrightness;
 
+typedef enum {
+    BLMIN_STAT_ON,
+    BLMIN_STAT_OFF,
+    BLMIN_STAT_UNKNOWN
+} BLMIN_STAT_t;
+
 void BACKLIGHT_InitHardware();
 void BACKLIGHT_TurnOn();
 void BACKLIGHT_TurnOff();

--- a/settings.h
+++ b/settings.h
@@ -23,6 +23,7 @@
 #include "frequencies.h"
 #include <helper/battery.h>
 #include "radio.h"
+#include <driver/backlight.h>
 
 enum POWER_OnDisplayMode_t {
 	POWER_ON_DISPLAY_MODE_FULL_SCREEN = 0,
@@ -85,6 +86,7 @@ enum {
 	ACTION_OPT_A_B,
 	ACTION_OPT_VFO_MR,
 	ACTION_OPT_SWITCH_DEMODUL,
+	ACTION_OPT_BLMIN_TMP_OFF, //BackLight Minimum Temporay OFF
 	ACTION_OPT_LEN
 };
 
@@ -231,6 +233,7 @@ typedef struct {
 
 	uint8_t 			  KEY_M_LONG_PRESS_ACTION;
 	uint8_t               BACKLIGHT_MIN;
+	BLMIN_STAT_t		  BACKLIGHT_MIN_STAT;
 	uint8_t               BACKLIGHT_MAX;
 	BATTERY_Type_t		  BATTERY_TYPE;
 } EEPROM_Config_t;

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -361,6 +361,7 @@ const t_sidefunction SIDEFUNCTIONS[] =
 	{"SWITCH\nVFO",		ACTION_OPT_A_B},
 	{"VFO/MR",			ACTION_OPT_VFO_MR},
 	{"SWITCH\nDEMODUL",	ACTION_OPT_SWITCH_DEMODUL},
+	{"BLMIN\nTMP OFF",  ACTION_OPT_BLMIN_TMP_OFF}, 		//BackLight Minimum Temporay OFF
 };
 const t_sidefunction* gSubMenu_SIDEFUNCTIONS = SIDEFUNCTIONS;
 const uint8_t gSubMenu_SIDEFUNCTIONS_size = ARRAY_SIZE(SIDEFUNCTIONS);


### PR DESCRIPTION
My Suggestion
When someone is using the BLMIN option, it is sometimes a good idea to turn off the screen for a while to save battery and then turn BLMIN back on - now you can do this with a programmable key. When the radio is turned on, the default state is to read the BLMIN value from the Eeprom and apply this setting.