### PR TITLE
Easy fix for docker compile on apple silicone.  Cleaned up readme a bit.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux:latest
+FROM --platform=amd64 archlinux:latest
 RUN pacman -Syyu base-devel --noconfirm
 RUN pacman -Syyu arm-none-eabi-gcc --noconfirm
 RUN pacman -Syyu arm-none-eabi-newlib --noconfirm

--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
-# Main features:
+# Open re-implementation of the Quansheng UV-K5 v2.1.27 firmware
+
+This repository is a merge of [OneOfEleven custom firmware](https://github.com/OneOfEleven/uv-k5-firmware-custom) with [fagci spectrum analizer](https://github.com/fagci/uv-k5-firmware-fagci-mod/tree/refactor) plus my few changes.
+
+All is a cloned and customized version of DualTachyon's open firmware found here ..
+
+https://github.com/DualTachyon/uv-k5-firmware .. a cool achievement !
+
+> [!WARNING]  
+> Use this firmware at your own risk (entirely). There is absolutely no guarantee that it will work in any way shape or form on your radio(s), it may even brick your radio(s), in which case, you'd need to buy another radio.
+Anyway, have fun.
+
+## Table of Contents
+
+* [Main Features](#main-features)
+* [Manual](#manual)
+* [Radio Performance](#radio-performance)
+* [User Customization](#user-customization)
+* [Compiler](#compiler)
+* [Building](#building)
+* [Credits](#credits)
+* [License](#license)
+* [Example changes/updates](#example-changesupdates)
+
+## Main features:
 * many of OneOfEleven mods:
    * AM fix, huge improvement in reception quality
-   * longpress buttons functions replicating F+ action
+   * long press buttons functions replicating F+ action
    * fast scanning
    * channel name editing in the menu
    * channel name + frequency display option
-   * shortcut for scannlist assignment (longpress `5 NOAA`)
-   * scannlist toggle (longpress `* Scan` while scanning)
+   * shortcut for scan-list assignment (long press `5 NOAA`)
+   * scan-list toggle (long press `* Scan` while scanning)
    * configurable button function selectable from menu
    * battery percentage/voltage on status bar, selectable from menu
    * longer backlight times
@@ -18,17 +42,17 @@
 * some other mods introduced by me:
    * SSB demodulation (adopted from fagci)
    * backlight dimming
-   * battery voltage callibration from menu
+   * battery voltage calibration from menu
    * better battery percentage calculation, selectable for 1600mAh or 2200mAh
    * more configurable button functions
-   * longpress MENU as another configurable button
+   * long press MENU as another configurable button
    * better DCS/CTCSS scanning in the menu (`* SCAN` while in RX DCS/CTCSS menu item)
    * Piotr022 s-meter style
    * restore initial freq/channel when scanning stopped with EXIT, remember last found transmission with MENU button
    * reordered and renamed menu entries
    * LCD interference crash fix
 
- # Manual
+ ## Manual
 
 * [Radio operation](https://github.com/egzumer/uv-k5-firmware-custom/wiki/Radio-operation)
 
@@ -42,22 +66,7 @@
 
 <img src="images/main.jpg" width=300 /><img src="images/spectrum.jpg" width=300 /><img src="images/audiobar.jpg" width=300 /><img src="images/rssibar.jpg" width=300 />
 
-
-# Open reimplementation of the Quan Sheng UV-K5 v2.1.27 firmware
-
-This repository is a merge of OneOfEleven custom firmware with fagci spectrum analizer plus my few changes.
-
-https://github.com/OneOfEleven/uv-k5-firmware-custom<br>
-https://github.com/fagci/uv-k5-firmware-fagci-mod/tree/refactor
-
-All is a cloned and customized version of DualTachyon's open firmware found here ..
-
-https://github.com/DualTachyon/uv-k5-firmware .. a cool achievement !
-
-Use this firmware at your own risk (entirely). There is absolutely no guarantee that it will work in any way shape or form on your radio(s), it may even brick your radio(s), in which case, you'd need to buy another radio.
-Anyway, have fun.
-
-# Radio performance
+## Radio performance
 
 Please note that the Quansheng UV-Kx radios are not professional quality transceivers, their
 performance is strictly limited. The RX front end has no track-tuned band pass filtering
@@ -68,12 +77,12 @@ easy (AM mode will suffer far more than FM ever will), the receiver simply doesn
 great dynamic range, which results in distorted AM audio with stronger RX'ed signals.
 There is nothing more anyone can do in firmware/software to improve that, once the RX gain
 adjustment I do (AM fix) reaches the hardwares limit, your AM RX audio will be all but
-non-existant (just like Quansheng's firmware).
+non-existent (just like Quansheng's firmware).
 On the other hand, FM RX audio will/should be fine.
 
 But, they are nice toys for the price, fun to play with.
 
-# User customization
+## User customization
 
 You can customize the firmware by enabling/disabling various compile options, this allows
 us to remove certain firmware features in order to make room in the flash for others.
@@ -83,42 +92,44 @@ You'll find the options at the top of "Makefile" ('0' = disable, '1' = enable) .
 ENABLE_CLANG                  := 0     **experimental, builds with clang instead of gcc (LTO will be disabled if you enable this)
 ENABLE_SWD                    := 0       only needed if using CPU's SWD port (debugging/programming)
 ENABLE_OVERLAY                := 0       cpu FLASH stuff, not needed
-ENABLE_LTO                    := 0     **experimental, reduces size of compiled firmware but might break EEPROM reads (OVERLAY will be disabled if you enable this)
+ENABLE_LTO                    := 1     **experimental, reduces size of compiled firmware but might break EEPROM reads (OVERLAY will be disabled if you enable this)
 ENABLE_UART                   := 1       without this you can't configure radio via PC !
 ENABLE_AIRCOPY                := 0       easier to just enter frequency with butts
-ENABLE_FMRADIO                := 0       WBFM VHF broadcast band receiver
+ENABLE_FMRADIO                := 1       WBFM VHF broadcast band receiver
 ENABLE_NOAA                   := 0       everything NOAA (only of any use in the USA)
 ENABLE_VOICE                  := 0       want to hear voices ?
-ENABLE_VOX                    := 0
+ENABLE_VOX                    := 1
 ENABLE_ALARM                  := 0       TX alarms
-ENABLE_1750HZ                 := 0       side key 1750Hz TX tone (older style repeater access)
-ENABLE_PWRON_PASSWORD         := 1       power-on password stuff
-ENABLE_BIG_FREQ               := 0       big font frequencies (like original QS firmware)
+ENABLE_TX1750                 := 0       side key 1750Hz TX tone (older style repeater access)
+ENABLE_PWRON_PASSWORD         := 0       power-on password stuff
+ENABLE_BIG_FREQ               := 1       big font frequencies (like original QS firmware)
 ENABLE_SMALL_BOLD             := 1       bold channel name/no. (when name + freq channel display mode)
 ENABLE_KEEP_MEM_NAME          := 1       maintain channel name when (re)saving memory channel
 ENABLE_WIDE_RX                := 1       full 18MHz to 1300MHz RX (though front-end/PA not designed for full range)
 ENABLE_TX_WHEN_AM             := 0       allow TX (always FM) when RX is set to AM
 ENABLE_F_CAL_MENU             := 0       enable the radios hidden frequency calibration menu
-ENABLE_CTCSS_TAIL_PHASE_SHIFT := 1       standard CTCSS tail phase shift rather than QS's own 55Hz tone method
+ENABLE_CTCSS_TAIL_PHASE_SHIFT := 0       standard CTCSS tail phase shift rather than QS's own 55Hz tone method
 ENABLE_BOOT_BEEPS             := 0       gives user audio feedback on volume knob position at boot-up
-ENABLE_SHOW_CHARGE_LEVEL      := 0       show the charge level when the radio is on charge
-ENABLE_REVERSE_BAT_SYMBOL     := 1       mirror the battery symbol on the status bar (+ pole on the right)
+ENABLE_SHOW_CHARGE_LEVEL      := 1       show the charge level when the radio is on charge
+ENABLE_REVERSE_BAT_SYMBOL     := 0       mirror the battery symbol on the status bar (+ pole on the right)
 ENABLE_NO_CODE_SCAN_TIMEOUT   := 1       disable 32-sec CTCSS/DCS scan timeout (press exit butt instead of time-out to end scan)
-ENABLE_AM_FIX                 := 1       dynamically adjust the front end gains when in AM mode to helo prevent AM demodulator saturation, ignore the on-screen RSSI level (for now)
-ENABLE_AM_FIX_SHOW_DATA       := 1       show debug data for the AM fix (still tweaking it)
-ENABLE_SQUELCH_MORE_SENSITIVE := 0       make squelch levels a little bit more sensitive - I plan to let user adjust the values themselves
-ENABLE_FASTER_CHANNEL_SCAN    := 0       increases the channel scan speed, but the squelch is also made more twitchy
-ENABLE_RSSI_BAR               := 1       enable a dBm/Sn RSSI bar graph level inplace of the little antenna symbols
-ENABLE_AUDIO_BAR              := 0       experimental, display an audio bar level when TX'ing
+ENABLE_AM_FIX                 := 1       dynamically adjust the front end gains when in AM mode to help prevent AM demodulator saturation, ignore the on-screen RSSI level (for now)
+ENABLE_AM_FIX_SHOW_DATA       := 0       show debug data for the AM fix
+ENABLE_SQUELCH_MORE_SENSITIVE := 1       make squelch levels a little bit more sensitive - I plan to let user adjust the values themselves
+ENABLE_FASTER_CHANNEL_SCAN    := 1       increases the channel scan speed, but the squelch is also made more twitchy
+ENABLE_RSSI_BAR               := 1       enable a dBm/Sn RSSI bar graph level in place of the little antenna symbols
+ENABLE_AUDIO_BAR              := 1       experimental, display an audio bar level when TX'ing
 ENABLE_COPY_CHAN_TO_VFO       := 1       copy current channel into the other VFO. Long press `1 BAND` when in channel mode
-ENABLE_SPECTRUM               := 1       fagci spectrum analizer, activated with `F` + `5 NOAA`
+ENABLE_SPECTRUM               := 1       fagci spectrum analyzer, activated with `F` + `5 NOAA`
 ENABLE_REDUCE_LOW_MID_TX_POWER:= 0       makes medium and low power settings even lower
-ENABLE_BYP_RAW_DEMODULATORS   := 0       additional BYP (bypass?) and RAW demodulation options, prooved not to be very usefull, but it is there if you want to experiment
+ENABLE_BYP_RAW_DEMODULATORS   := 0       additional BYP (bypass?) and RAW demodulation options, proved not to be very useful, but it is there if you want to experiment
 ENABLE_BLMIN_TMP_OFF          := 0       additional function for configurable buttons that toggles `BLMin` on and off wihout saving it to the EEPROM
+ENABLE_SCAN_RANGES            := 1       set VFO for A & B then hold NOAA button to scan within range 
+ENABLE_DTMF_CALLING           := 1       use * Scan button to enter DTMF code and then PTT to send
 ```
 
 
-# Compiler
+## Compiler
 
 arm-none-eabi GCC version 10.3.1 is recommended, which is the current version on Ubuntu 22.04.03 LTS.
 Other versions may generate a flash file that is too big.
@@ -127,9 +138,9 @@ You can get an appropriate version from: https://developer.arm.com/downloads/-/g
 clang may be used but isn't fully supported. Resulting binaries may also be bigger.
 You can get it from: https://releases.llvm.org/download.html
 
-# Building
+## Building
 
-If you have docker installed you can use `compile-with-docker.bat`, the output files are created in `compiled-firmware` folder. This method gives significantly smaller binaries, I've seen differences up to 1kb, so it can fit more functionalities this way. The challange can be (or not) installing the docker itself.
+If you have docker installed you can use [compile-with-docker.bat](./compile-with-docker.bat) (Windows) or [compile-with-docker.sh](./compile-with-docker.sh) (Linux/Mac), the output files are created in `compiled-firmware` folder. This method gives significantly smaller binaries, I've seen differences up to 1kb, so it can fit more functionalities this way. The challenge can be (or not) installing docker itself.
 
 
 To compile directly in windows:
@@ -159,7 +170,7 @@ To compile directly in windows:
 
 I've left some notes in the win_make.bat file to maybe help with stuff.
 
-# Credits
+## Credits
 
 Many thanks to various people on Telegram for putting up with me during this effort and helping:
 
@@ -177,7 +188,7 @@ Many thanks to various people on Telegram for putting up with me during this eff
 * @d1ced95
 * and others I forget
 
-# License
+## License
 
 Copyright 2023 Dual Tachyon
 https://github.com/DualTachyon
@@ -194,7 +205,7 @@ You may obtain a copy of the License at
     See the License for the specific language governing permissions and
     limitations under the License.
 
-# Example changes/updates
+## Example changes/updates
 
 <p float="left">
   <img src="/images/image1.png" width=300 />


### PR DESCRIPTION
Love this firmware. Thank you for pulling it all together and making it easy to install.  There are alternatives, but your flavour is cohesive, opinionated, and well documented.  ❤️

This is a very small PR:

1. Add `--platform=amd64` to the Dockerfile
 - Docker on the new 'apple silicone' macs tries to pull arm64 images from docker hub.  This fails because the archlinux image only supports _amd64_.  Adding `--platform=amd64` fixes this issue on macs and has no negative impact on amd64 devices.
   - I flashed the compiled image on a UV-K5 (wouldn't dare risk one of my K8 variants, lol) and it works as expected, no errors.
2. Cleanup README.md (a bit) [preview](https://github.com/egzumer/uv-k5-firmware-custom/blob/911bfa8d10953601c95d38eb1f2a36f5fcd0ab6c/README.md)
 - Move 'Open re-implementation' section to the top to act as an 'intro'.
   - Make all remaining sections H2 (##) because I'm OCD like that.
 - Encapsulate 'use at your own risk' message in a warning block-quote.
 - Add a table of contents
 - Fix some spelling issues
 - Set default values in 'User customization' section to match what is set in the Makefile
   - Add 'ENABLE_SCAN_RANGES' and 'ENABLE_DTMF_CALLING' to the list. 