### PR TITLE
Improve Am-Fix for  Very Strong Signals

### DIFF
--- a/am_fix.c
+++ b/am_fix.c
@@ -29,6 +29,7 @@
 #include "frequencies.h"
 #include "functions.h"
 #include "misc.h"
+#include "radio.h"
 
 #ifdef ENABLE_AM_FIX
 
@@ -347,6 +348,8 @@
 			const int16_t new_rssi = BK4819_GetRSSI();
 			rssi                   = (prev_rssi[vfo] > 0) ? (prev_rssi[vfo] + new_rssi) / 2 : new_rssi;
 			prev_rssi[vfo]         = new_rssi;
+      
+      if(rssi > 200)      RADIO_SetupRegisters(true);                       //BK4819 Chip seems to lockup with very large signals. Gain changes no longer work. Resetting seems to fix it. G4EML
 		}
 
 		// save the corrected RSSI level


### PR DESCRIPTION
AM performance is much better with the new AM-Fix. However very strong signals (such as an aircraft within one mile) are still distorted. 
Some testing with a test signal source shows that this happens when the raw RSSI value from the BK4819 chip exceeds 200.  The chip seems to partially lock up and no longer responds to the gain changes being applied by AM-Fix.   AM-Fix tries to reduce the gain but it does not change. 

When in this condition with distorted audio if the monitor button is blipped the chip starts to respond again, the gain is reduced, and the audio is no longer distorted. 

Looking at what the monitor button does, the most significant thing is that it forces a setup of the BK4819 chips registers with a call to RADIO_SetupRegisters(). Effectively resetting the chip. 

This PR calls RADIO_SetupRegisters()  if AM-Fix detects a raw RSSI value of greater than 200. 

This fixes the problem, the gain is successfully reduced with extremely strong signals and they are are no longer distorted. 

Colin G4EML

Side Note.....  I am building using win_make.bat on windows 10,  the latest main build is reporting that the Flash memory is full. I have to turn off some of the features in Makefile to get it to build.  Different compilers might be slightly different but it is getting critical. 