### PR TITLE
fix: carrier channel scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ ENABLE_LTO                    := 1
 # ---- STOCK QUANSHENG FERATURES ----
 ENABLE_UART                   := 1
 ENABLE_AIRCOPY                := 0
-ENABLE_FMRADIO                := 1
+ENABLE_FMRADIO                := 0
 ENABLE_NOAA                   := 0
 ENABLE_VOICE                  := 0
 ENABLE_VOX                    := 1
 ENABLE_ALARM                  := 0
 ENABLE_TX1750                 := 0
-ENABLE_PWRON_PASSWORD         := 0
+ENABLE_PWRON_PASSWORD         := 1
 ENABLE_DTMF_CALLING           := 1
 
 # ---- CUSTOM MODS ----
@@ -424,6 +424,9 @@ debug:
 	/opt/openocd/bin/openocd -c "bindto 0.0.0.0" -f interface/jlink.cfg -f dp32g030.cfg
 
 flash:
+	k5prog -F -YYY -b firmware.bin
+
+flash-openocd:
 	/opt/openocd/bin/openocd -c "bindto 0.0.0.0" -f interface/jlink.cfg -f dp32g030.cfg -c "write_image firmware.bin 0; shutdown;"
 
 version.o: .FORCE

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ ENABLE_LTO                    := 1
 # ---- STOCK QUANSHENG FERATURES ----
 ENABLE_UART                   := 1
 ENABLE_AIRCOPY                := 0
-ENABLE_FMRADIO                := 0
+ENABLE_FMRADIO                := 1
 ENABLE_NOAA                   := 0
 ENABLE_VOICE                  := 0
 ENABLE_VOX                    := 1
 ENABLE_ALARM                  := 0
 ENABLE_TX1750                 := 0
-ENABLE_PWRON_PASSWORD         := 1
+ENABLE_PWRON_PASSWORD         := 0
 ENABLE_DTMF_CALLING           := 1
 
 # ---- CUSTOM MODS ----

--- a/app/app.c
+++ b/app/app.c
@@ -386,7 +386,7 @@ Skip:
 						break;
 
 					case SCAN_RESUME_CO:
-						gScanPauseDelayIn_10ms = scan_pause_delay_in_7_10ms;
+						gScanPauseDelayIn_10ms = scan_pause_delay_in_6_10ms;
 						gScheduleScanListen    = false;
 						break;
 


### PR DESCRIPTION
Fixes long wait in channel search mode when 'CARRIER' setting is applied. Before 'CARRIER' was acting like 'TIMEOUT' setting.