### PR TITLE
Fix compilation errors

### DIFF
--- a/app/action.c
+++ b/app/action.c
@@ -57,7 +57,6 @@ inline static void ACTION_ScanRestart() { ACTION_Scan(true); };
 
 void (*action_opt_table[])(void) = {
 	[ACTION_OPT_NONE] = &FUNCTION_NOP,
-	[ACTION_OPT_FLASHLIGHT] = &ACTION_FlashLight,
 	[ACTION_OPT_POWER] = &ACTION_Power,
 	[ACTION_OPT_MONITOR] = &ACTION_Monitor,
 	[ACTION_OPT_SCAN] = &ACTION_ScanRestart,
@@ -65,6 +64,12 @@ void (*action_opt_table[])(void) = {
 	[ACTION_OPT_A_B] = &COMMON_SwitchVFOs,
 	[ACTION_OPT_VFO_MR] = &COMMON_SwitchVFOMode,
 	[ACTION_OPT_SWITCH_DEMODUL] = &ACTION_SwitchDemodul,
+
+#ifdef ENABLE_FLASHLIGHT
+	[ACTION_OPT_FLASHLIGHT] = &ACTION_FlashLight,
+#else
+	[ACTION_OPT_FLASHLIGHT] = &FUNCTION_NOP,
+#endif
 
 #ifdef ENABLE_VOX
 	[ACTION_OPT_VOX] = &ACTION_Vox,

--- a/app/app.c
+++ b/app/app.c
@@ -37,7 +37,10 @@
 #include "app/main.h"
 #include "app/menu.h"
 #include "app/scanner.h"
-#include "app/uart.h"
+#ifdef ENABLE_UART
+	#include "app/uart.h"
+	#include "debugging.h"
+#endif
 #include "ARMCM0.h"
 #include "audio.h"
 #include "board.h"
@@ -69,8 +72,6 @@
 #include "ui/menu.h"
 #include "ui/status.h"
 #include "ui/ui.h"
-
-#include "debugging.h"
 
 static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld);
 
@@ -1137,23 +1138,25 @@ void APP_TimeSlice10ms(void)
 {
 	gFlashLightBlinkCounter++;
 
-	#ifdef ENABLE_BOOT_BEEPS
-		if (boot_counter_10ms > 0)
-			if ((boot_counter_10ms % 25) == 0)
-				AUDIO_PlayBeep(BEEP_880HZ_40MS_OPTIONAL);
-	#endif
+#ifdef ENABLE_BOOT_BEEPS
+	if (boot_counter_10ms > 0 && (boot_counter_10ms % 25) == 0) {
+		AUDIO_PlayBeep(BEEP_880HZ_40MS_OPTIONAL);
+	}
+#endif
 
-	#ifdef ENABLE_AM_FIX
-		if (gRxVfo->Modulation == MODULATION_AM)
-			AM_fix_10ms(gEeprom.RX_VFO);
-	#endif
+#ifdef ENABLE_AM_FIX
+	if (gRxVfo->Modulation == MODULATION_AM) {
+		AM_fix_10ms(gEeprom.RX_VFO);
+	}
+#endif
 
-	if (UART_IsCommandAvailable())
-	{
+#ifdef ENABLE_UART
+	if (UART_IsCommandAvailable()) {
 		__disable_irq();
 		UART_HandleCommand();
 		__enable_irq();
 	}
+#endif
 
 	if (gReducedService)
 		return;

--- a/app/generic.c
+++ b/app/generic.c
@@ -83,7 +83,9 @@ void GENERIC_Key_F(bool bKeyPressed, bool bKeyHeld)
 	}
 	else // short pressed
 	{
+#ifdef ENABLE_FMRADIO
 		if (gScreenToDisplay != DISPLAY_FM)
+#endif
 		{
 			gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 			return;
@@ -221,17 +223,24 @@ start_tx:
 	// request start TX
 	gFlagPrepareTX = true;
 	goto done;
-	
+
 cancel_tx:
 	if (gPttIsPressed)
 	{
 		gPttWasPressed = true;
 	}
 
-done:	
+done:
 	gPttDebounceCounter = 0;
-	if (gScreenToDisplay != DISPLAY_MENU && gRequestDisplayScreen != DISPLAY_FM)     // 1of11 .. don't close the menu
+	if (gScreenToDisplay != DISPLAY_MENU
+#ifdef ENABLE_FMRADIO
+		&& gRequestDisplayScreen != DISPLAY_FM
+#endif
+	) {
+		// 1of11 .. don't close the menu
 		gRequestDisplayScreen = DISPLAY_MAIN;
+	}
+
 	gUpdateStatus  = true;
 	gUpdateDisplay = true;
 }

--- a/board.c
+++ b/board.c
@@ -50,10 +50,10 @@
 		FLASH_Init(FLASH_READ_MODE_1_CYCLE);
 		FLASH_ConfigureTrimValues();
 		SYSTEM_ConfigureClocks();
-	
+
 		overlay_FLASH_MainClock       = 48000000;
 		overlay_FLASH_ClockMultiplier = 48;
-	
+
 		FLASH_Init(FLASH_READ_MODE_2_CYCLE);
 	}
 #endif
@@ -494,10 +494,12 @@ void BOARD_Init(void)
 	BACKLIGHT_InitHardware();
 	BOARD_ADC_Init();
 	ST7565_Init();
-	#ifdef ENABLE_FMRADIO
+#ifdef ENABLE_FMRADIO
 		BK1080_Init(0, false);
-	#endif
+#endif
+
+#if defined(ENABLE_UART) || defined(ENABLED_AIRCOPY)
 	CRC_Init();
+#endif
+
 }
-
-

--- a/debugging.h
+++ b/debugging.h
@@ -1,35 +1,38 @@
 #ifndef DEBUGGING_H
 #define DEBUGGING_H
 
+#ifdef ENABLE_UART
+
 #include "driver/uart.h"
 #include "driver/bk4819.h"
 #include "string.h"
 #include "external/printf/printf.h"
 #include "am_fix.h"
 
-
-static inline void LogUart(const char * const str)
+static inline void LogUart(const char *const str)
 {
-    UART_Send(str, strlen(str));
+	UART_Send(str, strlen(str));
 }
 
 static inline void LogRegUart(uint16_t reg)
 {
-    uint16_t regVal = BK4819_ReadRegister(reg);
-    char buf[32];
-    sprintf(buf, "reg%02X: %04X\n", reg, regVal);
-    LogUart(buf);
+	uint16_t regVal = BK4819_ReadRegister(reg);
+	char buf[32];
+	sprintf(buf, "reg%02X: %04X\n", reg, regVal);
+	LogUart(buf);
 }
-
 
 static inline void LogPrint()
 {
-    uint16_t rssi = BK4819_GetRSSI();
-    uint16_t reg7e = BK4819_ReadRegister(0x7E);
-    char buf[32];
-    sprintf(buf, "reg7E: %d  %2d  %6d  %2d  %d   rssi: %d\n", 
-        (reg7e >> 15), (reg7e >> 12) & 0b111, (reg7e >> 5) & 0b1111111, (reg7e >> 2) & 0b111, (reg7e >> 0) & 0b11, rssi);
-    LogUart(buf);
+	uint16_t rssi = BK4819_GetRSSI();
+	uint16_t reg7e = BK4819_ReadRegister(0x7E);
+	char buf[32];
+	sprintf(buf, "reg7E: %d  %2d  %6d  %2d  %d   rssi: %d\n", (reg7e >> 15),
+		(reg7e >> 12) & 0b111, (reg7e >> 5) & 0b1111111,
+		(reg7e >> 2) & 0b111, (reg7e >> 0) & 0b11, rssi);
+	LogUart(buf);
 }
+
+#endif
 
 #endif

--- a/driver/crc.c
+++ b/driver/crc.c
@@ -14,8 +14,8 @@
  *     limitations under the License.
  */
 
-#include "bsp/dp32g030/crc.h"
-#include "driver/crc.h"
+#include "../bsp/dp32g030/crc.h"
+#include "crc.h"
 
 void CRC_Init(void)
 {
@@ -47,4 +47,3 @@ uint16_t CRC_Calculate(const void *pBuffer, uint16_t Size)
 
 	return Crc;
 }
-

--- a/main.c
+++ b/main.c
@@ -31,7 +31,9 @@
 #include "driver/gpio.h"
 #include "driver/system.h"
 #include "driver/systick.h"
-#include "driver/uart.h"
+#ifdef ENABLE_UART
+	#include "driver/uart.h"
+#endif
 #include "helper/battery.h"
 #include "helper/boot.h"
 #include "misc.h"
@@ -42,16 +44,17 @@
 #include "ui/menu.h"
 #include "version.h"
 
-void _putchar(char c)
+void _putchar(__attribute__((unused)) char c)
 {
+
+#ifdef ENABLE_UART
 	UART_Send((uint8_t *)&c, 1);
+#endif
+
 }
 
 void Main(void)
 {
-	unsigned int i;
-	BOOT_Mode_t  BootMode;
-
 	// Enable clock gating of blocks we need
 	SYSCON_DEV_CLK_GATE = 0
 		| SYSCON_DEV_CLK_GATE_GPIOA_BITS_ENABLE
@@ -66,11 +69,13 @@ void Main(void)
 
 	SYSTICK_Init();
 	BOARD_Init();
-	UART_Init();
 
 	boot_counter_10ms = 250;   // 2.5 sec
 
+#ifdef ENABLE_UART
+	UART_Init();
 	UART_Send(UART_Version, strlen(UART_Version));
+#endif
 
 	// Not implementing authentic device checks
 
@@ -92,7 +97,7 @@ void Main(void)
 
 	RADIO_SetupRegisters(true);
 
-	for (i = 0; i < ARRAY_SIZE(gBatteryVoltages); i++)
+	for (unsigned int i = 0; i < ARRAY_SIZE(gBatteryVoltages); i++)
 		BOARD_ADC_GetBatteryInfo(&gBatteryVoltages[i], &gBatteryCurrent);
 
 	BATTERY_GetReadings(false);
@@ -101,8 +106,8 @@ void Main(void)
 		AM_fix_init();
 	#endif
 
-	BootMode = BOOT_GetMode();
-	
+	const BOOT_Mode_t  BootMode = BOOT_GetMode();
+
 	if (BootMode == BOOT_MODE_F_LOCK)
 	{
 		gF_LOCK = true;            // flag to say include the hidden menu items
@@ -124,8 +129,9 @@ void Main(void)
 	{	// keys are pressed
 		UI_DisplayReleaseKeys();
 		BACKLIGHT_TurnOn();
-		i = 0;
-		while (i < 50)  // 500ms
+
+		// 500ms
+		for (int i = 0; i < 50;)
 		{
 			i = (GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) && KEYBOARD_Poll() == KEY_INVALID) ? i + 1 : 0;
 			SYSTEM_DelayMs(10);

--- a/settings.c
+++ b/settings.c
@@ -22,7 +22,6 @@
 #endif
 #include "driver/bk4819.h"
 #include "driver/eeprom.h"
-#include "driver/uart.h"
 #include "misc.h"
 #include "settings.h"
 #include "ui/menu.h"

--- a/ui/lock.c
+++ b/ui/lock.c
@@ -143,13 +143,14 @@ void UI_DisplayLock(void)
 			gKeyReading0     = Key;
 		}
 
+#ifdef ENABLE_UART
 		if (UART_IsCommandAvailable())
 		{
 			__disable_irq();
 			UART_HandleCommand();
 			__enable_irq();
 		}
-
+#endif
 		if (gUpdateDisplay)
 		{
 			Render();

--- a/ui/main.c
+++ b/ui/main.c
@@ -19,7 +19,7 @@
 
 #include "app/chFrScanner.h"
 #include "app/dtmf.h"
-#ifdef ENABLE_AM_FIX_SHOW_DATA
+#ifdef ENABLE_AM_FIX
 	#include "am_fix.h"
 #endif
 #include "bitmaps.h"


### PR DESCRIPTION
Fixes #270, among other possible errors produced by disabling/enabling some build options.

It also fixes errors that could arise from disabling the UART but, to be honest, I have mixed feelings about even having the possibility of disabling the UART at all. I'd even remove the option of disabling the SWD interface.

Thoughts, @egzumer?