### PR TITLE
Fix #272: Backlight time doubled

### DIFF
--- a/driver/backlight.c
+++ b/driver/backlight.c
@@ -67,12 +67,12 @@ void BACKLIGHT_TurnOn(void)
 		case 1:	// 5 sec
 		case 2:	// 10 sec
 		case 3:	// 20 sec
-			gBacklightCountdown_500ms = 1 + (2 << (gEeprom.BACKLIGHT_TIME - 1)) * 10;
+			gBacklightCountdown_500ms = 1 + (2 << (gEeprom.BACKLIGHT_TIME - 1)) * 5;
 			break;
 		case 4:	// 1 min
 		case 5:	// 2 min
 		case 6:	// 4 min
-			gBacklightCountdown_500ms = 1 + (2 << (gEeprom.BACKLIGHT_TIME - 4)) * 120;
+			gBacklightCountdown_500ms = 1 + (2 << (gEeprom.BACKLIGHT_TIME - 4)) * 60;
 			break;
 		case 7:	// always on
 			gBacklightCountdown_500ms = 0;


### PR DESCRIPTION
There was an additional 2-factor. With the corrected formulas:

```
>>> 1 + (2 << 1-1) * 5
11 (i.e., 5.5s)
>>> 1 + (2 << 4-4) * 60
121 (i.e., 60.5s)
```

