### PR TITLE
Refactorings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ firmware
 compile_commands.json
 .vscode
 /docs
+k5_eeprom.raw

--- a/am_fix.c
+++ b/am_fix.c
@@ -120,7 +120,7 @@ static const t_gain_table gain_table[] =
 	{0x003E,-50},   // 20 .. 0 1 3 6 .. -28dB -19dB  0dB  -3dB .. -50dB
 	{0x003F,-47},   // 21 .. 0 1 3 7 .. -28dB -19dB  0dB   0dB .. -47dB
 	{0x005E,-45},   // 22 .. 0 2 3 6 .. -28dB -14dB  0dB  -3dB .. -45dB
-	{0x005F,-42},   // 23 .. 0 2 3 7 .. -28dB -14dB  0dB   0dB .. -42dB              
+	{0x005F,-42},   // 23 .. 0 2 3 7 .. -28dB -14dB  0dB   0dB .. -42dB
 	{0x007E,-40},   // 24 .. 0 3 3 6 .. -28dB  -9dB  0dB  -3dB .. -40dB
 	{0x007F,-37},   // 25 .. 0 3 3 7 .. -28dB  -9dB  0dB   0dB .. -37dB
 	{0x009F,-34},   // 26 .. 0 4 3 7 .. -28dB  -6dB  0dB   0dB .. -34dB
@@ -140,8 +140,8 @@ static const t_gain_table gain_table[] =
 	{0x03BF,-4},    // 40 .. 3 5 3 7 ..   0dB  -4dB  0dB   0dB ..  -4dB
 	{0x03DF,-2},    // 41 .. 3 6 3 7 ..   0dB - 2dB  0dB   0dB ..  -2dB
 	{0x03FF,0}      // 42 .. 3 7 3 7 ..   0dB   0dB  0dB   0dB ..   0dB
-	
 };
+
 const uint8_t gain_table_size = ARRAY_SIZE(gain_table);
 #else
 
@@ -260,22 +260,11 @@ void AM_fix_10ms(const unsigned vfo)
 	if(!gSetting_AM_fix || !enabled || vfo > 1 )
 		return;
 
-	switch (gCurrentFunction)
-	{
-		case FUNCTION_TRANSMIT:
-		case FUNCTION_BAND_SCOPE:
-		case FUNCTION_POWER_SAVE:
+	if (gCurrentFunction != FUNCTION_FOREGROUND && !FUNCTION_IsRx()) {
 #ifdef ENABLE_AM_FIX_SHOW_DATA
-			counter = display_update_rate;  // queue up a display update as soon as we switch to RX mode
+		counter = display_update_rate;  // queue up a display update as soon as we switch to RX mode
 #endif
-			return;
-
-		// only adjust stuff if we're in one of these modes
-		case FUNCTION_FOREGROUND:
-		case FUNCTION_RECEIVE:
-		case FUNCTION_MONITOR:
-		case FUNCTION_INCOMING:
-			break;
+		return;
 	}
 
 #ifdef ENABLE_AM_FIX_SHOW_DATA
@@ -304,11 +293,11 @@ void AM_fix_10ms(const unsigned vfo)
 #ifdef ENABLE_AM_FIX_SHOW_DATA
 	{
 		static int16_t lastRssi;
-		
+
 		if (lastRssi != rssi) { // rssi changed
 			lastRssi = rssi;
 
-			if (counter == 0) {	
+			if (counter == 0) {
 				counter        = 1;
 				gUpdateDisplay = true; // trigger a display update
 			}

--- a/app/app.c
+++ b/app/app.c
@@ -409,36 +409,28 @@ Skip:
 	}
 }
 
+static void HandlePowerSave()
+{
+	if (!gRxIdleMode) {
+		CheckForIncoming();
+	}
+}
+
+static void (*HandleFunction_fn_table[])(void) = {
+	[FUNCTION_FOREGROUND] = &CheckForIncoming,
+	[FUNCTION_TRANSMIT] = &FUNCTION_NOP,
+	[FUNCTION_MONITOR] = &FUNCTION_NOP,
+	[FUNCTION_INCOMING] = &HandleIncoming,
+	[FUNCTION_RECEIVE] = &HandleReceive,
+	[FUNCTION_POWER_SAVE] = &HandlePowerSave,
+	[FUNCTION_BAND_SCOPE] = &FUNCTION_NOP,
+};
+
+static_assert(ARRAY_SIZE(HandleFunction_fn_table) == FUNCTION_N_ELEM);
+
 static void HandleFunction(void)
 {
-	switch (gCurrentFunction)
-	{
-		case FUNCTION_FOREGROUND:
-			CheckForIncoming();
-			break;
-
-		case FUNCTION_TRANSMIT:
-			break;
-
-		case FUNCTION_MONITOR:
-			break;
-
-		case FUNCTION_INCOMING:
-			HandleIncoming();
-			break;
-
-		case FUNCTION_RECEIVE:
-			HandleReceive();
-			break;
-
-		case FUNCTION_POWER_SAVE:
-			if (!gRxIdleMode)
-				CheckForIncoming();
-			break;
-
-		case FUNCTION_BAND_SCOPE:
-			break;
-	}
+	HandleFunction_fn_table[gCurrentFunction]();
 }
 
 void APP_StartListening(FUNCTION_Type_t function)

--- a/app/dtmf.c
+++ b/app/dtmf.c
@@ -138,13 +138,14 @@ bool DTMF_ValidateCodes(char *pCode, const unsigned int size)
 #ifdef ENABLE_DTMF_CALLING
 bool DTMF_GetContact(const int Index, char *pContact)
 {
-	int i = -1;
-	if (Index >= 0 && Index < MAX_DTMF_CONTACTS && pContact != NULL)
-	{
-		EEPROM_ReadBuffer(0x1C00 + (Index * 16), pContact, 16);
-		i = (int)pContact[0] - ' ';
+	if (Index < 0 || Index >= MAX_DTMF_CONTACTS || pContact == NULL) {
+		return false;
 	}
-	return (i >= 0 && i < 95);
+
+	EEPROM_ReadBuffer(0x1C00 + (Index * 16), pContact, 16);
+
+	// check whether the first character is printable or not
+	return (pContact[0] >= ' ' && pContact[0] < 127);
 }
 
 bool DTMF_FindContact(const char *pContact, char *pResult)
@@ -331,13 +332,12 @@ void DTMF_HandleRequest(void)
 
 	if (gDTMF_RX_index >= 2)
 	{	// look for ACK reply
+		char *pPrintStr = "AB";
 
-		strcpy(String, "AB");
+		Offset = gDTMF_RX_index - strlen(pPrintStr);
 
-		Offset = gDTMF_RX_index - strlen(String);
-
-		if (CompareMessage(gDTMF_RX + Offset, String, strlen(String), true))
-		{	// ends with "AB"
+		if (CompareMessage(gDTMF_RX + Offset, pPrintStr, strlen(pPrintStr), true)) {
+			// ends with "AB"
 
 			if (gDTMF_ReplyState != DTMF_REPLY_NONE)          // 1of11
 //			if (gDTMF_CallState != DTMF_CALL_STATE_NONE)      // 1of11

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -1075,7 +1075,7 @@ static void RenderStill() {
 }
 
 static void Render() {
-  memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+  UI_DisplayClear();
 
   switch (currentState) {
   case SPECTRUM:

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -726,7 +726,7 @@ static void DrawStatus() {
 
 static void DrawF(uint32_t f) {
   sprintf(String, "%u.%05u", f / 100000, f % 100000);
-  UI_PrintStringSmall(String, 8, 127, 0);
+  UI_PrintStringSmallNormal(String, 8, 127, 0);
 
   sprintf(String, "%3s", gModulationStr[settings.modulationType]);
   GUI_DisplaySmallest(String, 116, 1, false, true);

--- a/bitmaps.h
+++ b/bitmaps.h
@@ -43,6 +43,4 @@ extern const uint8_t BITMAP_ScanList1[6];
 extern const uint8_t BITMAP_ScanList2[6];
 
 extern const uint8_t BITMAP_compand[6];
-
 #endif
-

--- a/driver/eeprom.c
+++ b/driver/eeprom.c
@@ -47,15 +47,16 @@ void EEPROM_WriteBuffer(uint16_t Address, const void *pBuffer)
 
 	uint8_t buffer[8];
 	EEPROM_ReadBuffer(Address, buffer, 8);
-	if (memcmp(pBuffer, buffer, 8) != 0)
-	{
-		I2C_Start();
-		I2C_Write(0xA0);
-		I2C_Write((Address >> 8) & 0xFF);
-		I2C_Write((Address >> 0) & 0xFF);
-		I2C_WriteBuffer(pBuffer, 8);
-		I2C_Stop();
+	if (memcmp(pBuffer, buffer, 8) == 0) {
+		return;
 	}
+
+	I2C_Start();
+	I2C_Write(0xA0);
+	I2C_Write((Address >> 8) & 0xFF);
+	I2C_Write((Address >> 0) & 0xFF);
+	I2C_WriteBuffer(pBuffer, 8);
+	I2C_Stop();
 
 	// give the EEPROM time to burn the data in (apparently takes 5ms)
 	SYSTEM_DelayMs(8);

--- a/functions.c
+++ b/functions.c
@@ -261,6 +261,7 @@ void FUNCTION_Select(FUNCTION_Type_t Function)
 		case FUNCTION_INCOMING:
 		case FUNCTION_RECEIVE:
 		case FUNCTION_BAND_SCOPE:
+		default:
 			break;
 	}
 

--- a/functions.h
+++ b/functions.h
@@ -27,7 +27,8 @@ enum FUNCTION_Type_t
 	FUNCTION_INCOMING,        // receiving a signal (squelch is open)
 	FUNCTION_RECEIVE,         // RX mode, squelch closed
 	FUNCTION_POWER_SAVE,      // sleeping
-	FUNCTION_BAND_SCOPE       // bandscope mode (panadpter/spectrum) .. not yet implemented
+	FUNCTION_BAND_SCOPE,      // bandscope mode (panadpter/spectrum) .. not yet implemented
+	FUNCTION_N_ELEM
 };
 
 typedef enum FUNCTION_Type_t FUNCTION_Type_t;

--- a/misc.h
+++ b/misc.h
@@ -175,7 +175,7 @@ extern uint16_t              gEEPROM_RSSI_CALIB[7][4];
 extern uint16_t              gEEPROM_1F8A;
 extern uint16_t              gEEPROM_1F8C;
 
-typedef union { 
+typedef union {
     struct {
         uint8_t
             band : 4,

--- a/settings.c
+++ b/settings.c
@@ -35,16 +35,11 @@ static const uint32_t gDefaultFrequencyTable[] =
 	43350000     //
 };
 
-EEPROM_Config_t gEeprom;
+EEPROM_Config_t gEeprom = { 0 };
 
 void SETTINGS_InitEEPROM(void)
 {
-	unsigned int i;
-	uint8_t      Data[16];
-
-	memset(Data, 0, sizeof(Data));
-	memset(&gEeprom, 0, sizeof(gEeprom));
-
+	uint8_t Data[16] = {0};
 	// 0E70..0E77
 	EEPROM_ReadBuffer(0x0E70, Data, 8);
 	gEeprom.CHAN_1_CALL          = IS_MR_CHANNEL(Data[0]) ? Data[0] : MR_CHANNEL_FIRST;
@@ -129,11 +124,11 @@ void SETTINGS_InitEEPROM(void)
 
 	// 0E98..0E9F
 	EEPROM_ReadBuffer(0x0E98, Data, 8);
-	memmove(&gEeprom.POWER_ON_PASSWORD, Data, 4);
+	memcpy(&gEeprom.POWER_ON_PASSWORD, Data, 4);
 
 	// 0EA0..0EA7
 	EEPROM_ReadBuffer(0x0EA0, Data, 8);
-	#ifdef ENABLE_VOICE	
+	#ifdef ENABLE_VOICE
 	gEeprom.VOICE_PROMPT = (Data[0] < 3) ? Data[0] : VOICE_PROMPT_ENGLISH;
 	#endif
 	#ifdef ENABLE_RSSI_BAR
@@ -166,7 +161,7 @@ void SETTINGS_InitEEPROM(void)
 	gEeprom.DTMF_GROUP_CALL_CODE         = DTMF_ValidateCodes((char *)(Data + 2), 1) ? Data[2] : '#';
 	gEeprom.DTMF_DECODE_RESPONSE         = (Data[3] <   4) ? Data[3] : 0;
 	gEeprom.DTMF_auto_reset_time         = (Data[4] <  61) ? Data[4] : (Data[4] >= 5) ? Data[4] : 10;
-#endif		
+#endif
 	gEeprom.DTMF_PRELOAD_TIME            = (Data[5] < 101) ? Data[5] * 10 : 300;
 	gEeprom.DTMF_FIRST_CODE_PERSIST_TIME = (Data[6] < 101) ? Data[6] * 10 : 100;
 	gEeprom.DTMF_HASH_CODE_PERSIST_TIME  = (Data[7] < 101) ? Data[7] * 10 : 100;
@@ -180,62 +175,52 @@ void SETTINGS_InitEEPROM(void)
 
 	// 0EE0..0EE7
 
-	EEPROM_ReadBuffer(0x0EE0, Data, 8);
-	if (DTMF_ValidateCodes((char *)Data, 8))
-		memmove(gEeprom.ANI_DTMF_ID, Data, 8);
-	else
-	{
-		memset(gEeprom.ANI_DTMF_ID, 0, sizeof(gEeprom.ANI_DTMF_ID));
+	EEPROM_ReadBuffer(0x0EE0, Data, sizeof(gEeprom.ANI_DTMF_ID));
+	if (DTMF_ValidateCodes((char *)Data, sizeof(gEeprom.ANI_DTMF_ID))) {
+		memcpy(gEeprom.ANI_DTMF_ID, Data, sizeof(gEeprom.ANI_DTMF_ID));
+	} else {
 		strcpy(gEeprom.ANI_DTMF_ID, "123");
 	}
 
 
 	// 0EE8..0EEF
-	EEPROM_ReadBuffer(0x0EE8, Data, 8);
-	if (DTMF_ValidateCodes((char *)Data, 8))
-		memmove(gEeprom.KILL_CODE, Data, 8);
-	else
-	{
-		memset(gEeprom.KILL_CODE, 0, sizeof(gEeprom.KILL_CODE));
+	EEPROM_ReadBuffer(0x0EE8, Data, sizeof(gEeprom.KILL_CODE));
+	if (DTMF_ValidateCodes((char *)Data, sizeof(gEeprom.KILL_CODE))) {
+		memcpy(gEeprom.KILL_CODE, Data, sizeof(gEeprom.KILL_CODE));
+	} else {
 		strcpy(gEeprom.KILL_CODE, "ABCD9");
 	}
-	
+
 	// 0EF0..0EF7
-	EEPROM_ReadBuffer(0x0EF0, Data, 8);
-	if (DTMF_ValidateCodes((char *)Data, 8))
-		memmove(gEeprom.REVIVE_CODE, Data, 8);
-	else
-	{
-		memset(gEeprom.REVIVE_CODE, 0, sizeof(gEeprom.REVIVE_CODE));
+	EEPROM_ReadBuffer(0x0EF0, Data, sizeof(gEeprom.REVIVE_CODE));
+	if (DTMF_ValidateCodes((char *)Data, sizeof(gEeprom.REVIVE_CODE))) {
+		memcpy(gEeprom.REVIVE_CODE, Data, sizeof(gEeprom.REVIVE_CODE));
+	} else {
 		strcpy(gEeprom.REVIVE_CODE, "9DCBA");
 	}
 #endif
 
 	// 0EF8..0F07
-	EEPROM_ReadBuffer(0x0EF8, Data, 16);
-	if (DTMF_ValidateCodes((char *)Data, 16))
-		memmove(gEeprom.DTMF_UP_CODE, Data, 16);
-	else
-	{
-		memset(gEeprom.DTMF_UP_CODE, 0, sizeof(gEeprom.DTMF_UP_CODE));
+	EEPROM_ReadBuffer(0x0EF8, Data, sizeof(gEeprom.DTMF_UP_CODE));
+	if (DTMF_ValidateCodes((char *)Data, sizeof(gEeprom.DTMF_UP_CODE))) {
+		memcpy(gEeprom.DTMF_UP_CODE, Data, sizeof(gEeprom.DTMF_UP_CODE));
+	} else {
 		strcpy(gEeprom.DTMF_UP_CODE, "12345");
 	}
-	
+
 	// 0F08..0F17
-	EEPROM_ReadBuffer(0x0F08, Data, 16);
-	if (DTMF_ValidateCodes((char *)Data, 16))
-		memmove(gEeprom.DTMF_DOWN_CODE, Data, 16);
-	else
-	{
-		memset(gEeprom.DTMF_DOWN_CODE, 0, sizeof(gEeprom.DTMF_DOWN_CODE));
+	EEPROM_ReadBuffer(0x0F08, Data, sizeof(gEeprom.DTMF_DOWN_CODE));
+	if (DTMF_ValidateCodes((char *)Data, sizeof(gEeprom.DTMF_DOWN_CODE))) {
+		memcpy(gEeprom.DTMF_DOWN_CODE, Data, sizeof(gEeprom.DTMF_DOWN_CODE));
+	} else {
 		strcpy(gEeprom.DTMF_DOWN_CODE, "54321");
 	}
-	
+
 	// 0F18..0F1F
 	EEPROM_ReadBuffer(0x0F18, Data, 8);
 //	gEeprom.SCAN_LIST_DEFAULT = (Data[0] < 2) ? Data[0] : false;
 	gEeprom.SCAN_LIST_DEFAULT = (Data[0] < 3) ? Data[0] : false;  // we now have 'all' channel scan option
-	for (i = 0; i < 2; i++)
+	for (unsigned int i = 0; i < 2; i++)
 	{
 		const unsigned int j = 1 + (i * 3);
 		gEeprom.SCAN_LIST_ENABLED[i]     = (Data[j + 0] < 2) ? Data[j] : false;
@@ -255,13 +240,13 @@ void SETTINGS_InitEEPROM(void)
 	gSetting_350EN             = (Data[5] < 2) ? Data[5] : true;
 	gSetting_ScrambleEnable    = (Data[6] < 2) ? Data[6] : true;
 	//gSetting_TX_EN             = (Data[7] & (1u << 0)) ? true : false;
-	gSetting_live_DTMF_decoder = (Data[7] & (1u << 1)) ? true : false;
+	gSetting_live_DTMF_decoder = !!(Data[7] & (1u << 1));
 	gSetting_battery_text      = (((Data[7] >> 2) & 3u) <= 2) ? (Data[7] >> 2) & 3 : 2;
 	#ifdef ENABLE_AUDIO_BAR
-		gSetting_mic_bar       = (Data[7] & (1u << 4)) ? true : false;
+		gSetting_mic_bar       = !!(Data[7] & (1u << 4));
 	#endif
 	#ifdef ENABLE_AM_FIX
-		gSetting_AM_fix        = (Data[7] & (1u << 5)) ? true : false;
+		gSetting_AM_fix        = !!(Data[7] & (1u << 5));
 	#endif
 	gSetting_backlight_on_tx_rx = (Data[7] >> 6) & 3u;
 
@@ -278,13 +263,13 @@ void SETTINGS_InitEEPROM(void)
 		if(att->__val == 0xff){
 			att->__val = 0;
 			att->band = 0xf;
-		}	
+		}
 	}
 
 	// 0F30..0F3F
 	EEPROM_ReadBuffer(0x0F30, gCustomAesKey, sizeof(gCustomAesKey));
 	bHasCustomAesKey = false;
-	for (i = 0; i < ARRAY_SIZE(gCustomAesKey); i++)
+	for (unsigned int i = 0; i < ARRAY_SIZE(gCustomAesKey); i++)
 	{
 		if (gCustomAesKey[i] != 0xFFFFFFFFu)
 		{
@@ -319,7 +304,7 @@ void SETTINGS_LoadCalibration(void)
 		EEPROM_ReadBuffer(0x1F50 + (gEeprom.VOX_LEVEL * 2), &gEeprom.VOX1_THRESHOLD, 2);
 		EEPROM_ReadBuffer(0x1F68 + (gEeprom.VOX_LEVEL * 2), &gEeprom.VOX0_THRESHOLD, 2);
 	#endif
-	
+
 	//EEPROM_ReadBuffer(0x1F80 + gEeprom.MIC_SENSITIVITY, &Mic, 1);
 	//gEeprom.MIC_SENSITIVITY_TUNING = (Mic < 32) ? Mic : 15;
 	gEeprom.MIC_SENSITIVITY_TUNING = gMicGain_dB2[gEeprom.MIC_SENSITIVITY];
@@ -358,7 +343,7 @@ uint32_t SETTINGS_FetchChannelFrequency(const int channel)
 	} __attribute__((packed)) info;
 
 	EEPROM_ReadBuffer(channel * 16, &info, sizeof(info));
-	
+
 	return info.frequency;
 }
 
@@ -366,17 +351,16 @@ void SETTINGS_FetchChannelName(char *s, const int channel)
 {
 	if (s == NULL)
 		return;
-	
-	memset(s, 0, 11);  // 's' had better be large enough !
-	
+
+	s[0] = 0;
+
 	if (channel < 0)
 		return;
 
 	if (!RADIO_CheckValidChannel(channel, false, 0))
 		return;
 
-	EEPROM_ReadBuffer(0x0F50 + (channel * 16), s + 0, 8);
-	EEPROM_ReadBuffer(0x0F58 + (channel * 16), s + 8, 2);
+	EEPROM_ReadBuffer(0x0F50 + (channel * 16), s, 10);
 
 	int i;
 	for (i = 0; i < 10; i++)
@@ -538,7 +522,7 @@ void SETTINGS_SaveSettings(void)
 #ifdef ENABLE_RSSI_BAR
 	State[1] = gEeprom.S0_LEVEL;
 	State[2] = gEeprom.S9_LEVEL;
-#endif	
+#endif
 	EEPROM_WriteBuffer(0x0EA0, State);
 
 
@@ -559,7 +543,7 @@ void SETTINGS_SaveSettings(void)
 	State[2] = gEeprom.DTMF_GROUP_CALL_CODE;
 	State[3] = gEeprom.DTMF_DECODE_RESPONSE;
 	State[4] = gEeprom.DTMF_auto_reset_time;
-#endif	
+#endif
 	State[5] = gEeprom.DTMF_PRELOAD_TIME / 10U;
 	State[6] = gEeprom.DTMF_FIRST_CODE_PERSIST_TIME / 10U;
 	State[7] = gEeprom.DTMF_HASH_CODE_PERSIST_TIME / 10U;
@@ -603,7 +587,7 @@ void SETTINGS_SaveSettings(void)
 		if (!gSetting_AM_fix)            State[7] &= ~(1u << 5);
 	#endif
 	State[7] = (State[7] & ~(3u << 6)) | ((gSetting_backlight_on_tx_rx & 3u) << 6);
-	 
+
 	EEPROM_WriteBuffer(0x0F40, State);
 }
 
@@ -653,7 +637,7 @@ void SETTINGS_SaveChannel(uint8_t Channel, uint8_t VFO, const VFO_Info_t *pVFO, 
 
 			SETTINGS_UpdateChannel(Channel, pVFO, true);
 
-			if (IS_MR_CHANNEL(Channel)) {	
+			if (IS_MR_CHANNEL(Channel)) {
 				#ifndef ENABLE_KEEP_MEM_NAME
 					// clear/reset the channel name
 					SETTINGS_SaveChannelName(Channel, "");
@@ -680,9 +664,8 @@ void SETTINGS_SaveBatteryCalibration(const uint16_t * batteryCalibration)
 void SETTINGS_SaveChannelName(uint8_t channel, const char * name)
 {
 	uint16_t offset = channel * 16;
-	uint8_t  buf[16];
-	memset(&buf, 0x00, sizeof(buf));
-	memcpy(buf, name, MIN(strlen(name),10u));
+	uint8_t buf[16] = {0};
+	memcpy(buf, name, MIN(strlen(name), 10u));
 	EEPROM_WriteBuffer(0x0F50 + offset, buf);
 	EEPROM_WriteBuffer(0x0F58 + offset, buf + 8);
 }
@@ -729,7 +712,7 @@ void SETTINGS_UpdateChannel(uint8_t channel, const VFO_Info_t *pVFO, bool keep)
 
 void SETTINGS_WriteBuildOptions(void)
 {
-	uint8_t buf[8]= {};
+	uint8_t buf[8] = {0};
 buf[0] = 0
 #ifdef ENABLE_FMRADIO
     | (1 << 0)

--- a/ui/aircopy.c
+++ b/ui/aircopy.c
@@ -29,18 +29,18 @@
 
 void UI_DisplayAircopy(void)
 {
-	char String[16];
+	char String[16] = {0};
+	char *pPrintStr = { 0 };
 
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	if (gAircopyState == AIRCOPY_READY) {
+		pPrintStr = "AIR COPY(RDY)";
+	} else if (gAircopyState == AIRCOPY_TRANSFER) {
+		pPrintStr = "AIR COPY";
+	} else {
+		pPrintStr = "AIR COPY(CMP)";
+	}
 
-	if (gAircopyState == AIRCOPY_READY)
-		strcpy(String, "AIR COPY(RDY)");
-	else
-	if (gAircopyState == AIRCOPY_TRANSFER)
-		strcpy(String, "AIR COPY");
-	else
-		strcpy(String, "AIR COPY(CMP)");
-	UI_PrintString(String, 2, 127, 0, 8);
+	UI_PrintString(pPrintStr, 2, 127, 0, 8);
 
 	if (gInputBoxIndex == 0)
 	{

--- a/ui/aircopy.c
+++ b/ui/aircopy.c
@@ -47,7 +47,7 @@ void UI_DisplayAircopy(void)
 		uint32_t frequency = gRxVfo->freq_config_RX.Frequency;
 		sprintf(String, "%3u.%05u", frequency / 100000, frequency % 100000);
 		// show the remaining 2 small frequency digits
-		UI_PrintStringSmall(String + 7, 97, 0, 3);
+		UI_PrintStringSmallNormal(String + 7, 97, 0, 3);
 		String[7] = 0;
 		// show the main large frequency digits
 		UI_DisplayFrequency(String, 16, 2, false);

--- a/ui/fmradio.c
+++ b/ui/fmradio.c
@@ -30,82 +30,57 @@
 
 void UI_DisplayFM(void)
 {
-	unsigned int i;
-	char         String[16];
-
+	char String[16] = {0};
+	char *pPrintStr = String;
 	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
 
-	memset(String, 0, sizeof(String));
-	strcpy(String, "FM");
-	UI_PrintString(String, 0, 127, 0, 12);
+	UI_PrintString("FM", 0, 127, 0, 12);
 
-	memset(String, 0, sizeof(String));
-	if (gAskToSave)
-	{
-		strcpy(String, "SAVE?");
-	}
-	else
-	if (gAskToDelete)
-	{
-		strcpy(String, "DEL?");
-	}
-	else
-	{
-		if (gFM_ScanState == FM_SCAN_OFF)
-		{
-			if (!gEeprom.FM_IsMrMode)
-			{
-				for (i = 0; i < 20; i++)
-				{
-					if (gEeprom.FM_FrequencyPlaying == gFM_Channels[i])
-					{
-						sprintf(String, "VFO(CH%02u)", i + 1);
-						break;
-					}
+	if (gAskToSave) {
+		pPrintStr = "SAVE?";
+	} else if (gAskToDelete) {
+		pPrintStr = "DEL?";
+	} else if (gFM_ScanState == FM_SCAN_OFF) {
+		if (gEeprom.FM_IsMrMode) {
+			sprintf(String, "MR(CH%02u)", gEeprom.FM_SelectedChannel + 1);
+			pPrintStr = String;
+		} else {
+			pPrintStr = "VFO";
+			for (unsigned int i = 0; i < 20; i++) {
+				if (gEeprom.FM_FrequencyPlaying == gFM_Channels[i]) {
+					sprintf(String, "VFO(CH%02u)", i + 1);
+					pPrintStr = String;
+					break;
 				}
-
-				if (i == 20)
-					strcpy(String, "VFO");
 			}
-			else
-				sprintf(String, "MR(CH%02u)", gEeprom.FM_SelectedChannel + 1);
 		}
-		else
-		{
-			if (!gFM_AutoScan)
-				strcpy(String, "M-SCAN");
-			else
-				sprintf(String, "A-SCAN(%u)", gFM_ChannelPosition + 1);
-		}
+	} else if (gFM_AutoScan) {
+		sprintf(String, "A-SCAN(%u)", gFM_ChannelPosition + 1);
+		pPrintStr = String;
+	} else {
+		pPrintStr = "M-SCAN";
 	}
-	UI_PrintString(String, 0, 127, 2, 10);
+
+	UI_PrintString(pPrintStr, 0, 127, 2, 10);
 
 	memset(String, 0, sizeof(String));
-	if (gAskToSave || (gEeprom.FM_IsMrMode && gInputBoxIndex > 0))
-	{
+	if (gAskToSave || (gEeprom.FM_IsMrMode && gInputBoxIndex > 0)) {
 		UI_GenerateChannelString(String, gFM_ChannelPosition);
-	}
-	else
-	if (!gAskToDelete)
-	{
-		if (gInputBoxIndex == 0)
-		{
+	} else if (gAskToDelete) {
+		sprintf(String, "CH-%02u", gEeprom.FM_SelectedChannel + 1);
+	} else {
+		if (gInputBoxIndex == 0) {
 			sprintf(String, "%3d.%d", gEeprom.FM_FrequencyPlaying / 10, gEeprom.FM_FrequencyPlaying % 10);
-			UI_DisplayFrequency(String, 32, 4, true);
-		}
-		else {
+		} else {
 			const char * ascii = INPUTBOX_GetAscii();
 			sprintf(String, "%.3s.%.1s",ascii, ascii + 3);
-			UI_DisplayFrequency(String, 32, 4, false);
 		}
 
+		UI_DisplayFrequency(String, 32, 4, gInputBoxIndex == 0);
 		ST7565_BlitFullScreen();
 		return;
 	}
-	else
-	{
-		sprintf(String, "CH-%02u", gEeprom.FM_SelectedChannel + 1);
-	}
+
 	UI_PrintString(String, 0, 127, 4, 10);
 
 	ST7565_BlitFullScreen();

--- a/ui/fmradio.c
+++ b/ui/fmradio.c
@@ -32,7 +32,7 @@ void UI_DisplayFM(void)
 {
 	char String[16] = {0};
 	char *pPrintStr = String;
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	UI_DisplayClear();
 
 	UI_PrintString("FM", 0, 127, 0, 12);
 

--- a/ui/helper.c
+++ b/ui/helper.c
@@ -46,21 +46,23 @@ void UI_GenerateChannelString(char *pString, const uint8_t Channel)
 
 void UI_GenerateChannelStringEx(char *pString, const bool bShowPrefix, const uint8_t ChannelNumber)
 {
-	if (gInputBoxIndex > 0)
-	{
-		unsigned int i;
-		for (i = 0; i < 3; i++)
+	if (gInputBoxIndex > 0) {
+		for (unsigned int i = 0; i < 3; i++) {
 			pString[i] = (gInputBox[i] == 10) ? '-' : gInputBox[i] + '0';
+		}
+
+		pString[3] = 0;
 		return;
 	}
 
-	if (bShowPrefix)
+	if (bShowPrefix) {
+		// BUG here? Prefixed NULLs are allowed
 		sprintf(pString, "CH-%03u", ChannelNumber + 1);
-	else
-	if (ChannelNumber == 0xFF)
+	} else if (ChannelNumber == 0xFF) {
 		strcpy(pString, "NULL");
-	else
+	} else {
 		sprintf(pString, "%03u", ChannelNumber + 1);
+	}
 }
 
 void UI_PrintString(const char *pString, uint8_t Start, uint8_t End, uint8_t Line, uint8_t Width)
@@ -112,10 +114,10 @@ void UI_PrintStringSmall(const char *pString, uint8_t Start, uint8_t End, uint8_
 	{
 		const size_t Length = strlen(pString);
 		size_t       i;
-	
+
 		if (End > Start)
 			Start += (((End - Start) - (Length * 8)) + 1) / 2;
-	
+
 		const unsigned int char_width   = ARRAY_SIZE(gFontSmallBold[0]);
 		const unsigned int char_spacing = char_width + 1;
 		uint8_t            *pFb         = gFrameBuffer[Line] + Start;
@@ -171,7 +173,7 @@ void UI_DisplayFrequency(const char *string, uint8_t X, uint8_t Y, bool center)
 				*pFb1 = 0x60; pFb0++; pFb1++;
 				continue;
 			}
-			
+
 		}
 		else if (center) {
 			pFb0 -= 6;
@@ -182,7 +184,7 @@ void UI_DisplayFrequency(const char *string, uint8_t X, uint8_t Y, bool center)
 	}
 }
 
-void UI_DrawPixelBuffer(uint8_t (*buffer)[128], uint8_t x, uint8_t y, bool black) 
+void UI_DrawPixelBuffer(uint8_t (*buffer)[128], uint8_t x, uint8_t y, bool black)
 {
 	const uint8_t pattern = 1 << (y % 8);
 	if(black)
@@ -228,7 +230,7 @@ void UI_DrawRectangleBuffer(uint8_t (*buffer)[128], int16_t x1, int16_t y1, int1
 	UI_DrawLineBuffer(buffer, x1,y2, x2,y2, black);
 }
 
-void UI_DisplayPopup(const char *string) 
+void UI_DisplayPopup(const char *string)
 {
 	for(uint8_t i = 0; i < 7; i++) {
 		memset(gFrameBuffer[i], 0x00, 128);

--- a/ui/helper.c
+++ b/ui/helper.c
@@ -253,3 +253,8 @@ void UI_DisplayPopup(const char *string)
 	UI_PrintString(string, 9, 118, 2, 8);
 	UI_PrintStringSmall("Press EXIT", 9, 118, 6);
 }
+
+void UI_DisplayClear()
+{
+	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+}

--- a/ui/helper.h
+++ b/ui/helper.h
@@ -36,4 +36,6 @@ void UI_DrawPixelBuffer(uint8_t (*buffer)[128], uint8_t x, uint8_t y, bool black
 void UI_DrawLineBuffer(uint8_t (*buffer)[128], int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool black);
 void UI_DrawRectangleBuffer(uint8_t (*buffer)[128], int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool black);
 
+void UI_DisplayClear();
+
 #endif

--- a/ui/helper.h
+++ b/ui/helper.h
@@ -23,11 +23,10 @@
 void UI_GenerateChannelString(char *pString, const uint8_t Channel);
 void UI_GenerateChannelStringEx(char *pString, const bool bShowPrefix, const uint8_t ChannelNumber);
 void UI_PrintString(const char *pString, uint8_t Start, uint8_t End, uint8_t Line, uint8_t Width);
-void UI_PrintStringSmall(const char *pString, uint8_t Start, uint8_t End, uint8_t Line);
-#ifdef ENABLE_SMALL_BOLD
-	void UI_PrintStringSmallBold(const char *pString, uint8_t Start, uint8_t End, uint8_t Line);
-#endif
-void UI_PrintStringSmallBuffer(const char *pString, uint8_t *buffer);
+void UI_PrintStringSmallNormal(const char *pString, uint8_t Start, uint8_t End, uint8_t Line);
+void UI_PrintStringSmallBold(const char *pString, uint8_t Start, uint8_t End, uint8_t Line);
+void UI_PrintStringSmallBufferNormal(const char *pString, uint8_t *buffer);
+void UI_PrintStringSmallBufferBold(const char *pString, uint8_t * buffer);
 void UI_DisplayFrequency(const char *string, uint8_t X, uint8_t Y, bool center);
 
 void UI_DisplayPopup(const char *string);

--- a/ui/lock.c
+++ b/ui/lock.c
@@ -35,7 +35,7 @@ static void Render(void)
 	char         String[7];
 
 	memset(gStatusLine,  0, sizeof(gStatusLine));
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	UI_DisplayClear();
 
 	UI_PrintString("LOCK", 0, 127, 1, 10);
 	for (i = 0; i < 6; i++)

--- a/ui/lock.c
+++ b/ui/lock.c
@@ -37,8 +37,7 @@ static void Render(void)
 	memset(gStatusLine,  0, sizeof(gStatusLine));
 	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
 
-	strcpy(String, "LOCK");
-	UI_PrintString(String, 0, 127, 1, 10);
+	UI_PrintString("LOCK", 0, 127, 1, 10);
 	for (i = 0; i < 6; i++)
 		String[i] = (gInputBox[i] == 10) ? '-' : '*';
 	String[6] = 0;

--- a/ui/main.c
+++ b/ui/main.c
@@ -217,7 +217,7 @@ void DisplayRSSIBar(const bool now)
 		memcpy(p_line + 2 + 7*5, &plus, ARRAY_SIZE(plus));
 	}
 
-	UI_PrintStringSmall(str, 2, 0, line);
+	UI_PrintStringSmallNormal(str, 2, 0, line);
 	DrawLevelBar(bar_x, line, s_level + overS9Bars);
 	if (now)
 		ST7565_BlitLine(line);
@@ -280,7 +280,7 @@ static void PrintAGC(bool now)
 	int16_t agcGain = lnaShortTab[agcGainReg.lnaS] + lnaTab[agcGainReg.lna] + mixerTab[agcGainReg.mixer] + pgaTab[agcGainReg.pga];
 
 	sprintf(buf, "%d%2d %2d %2d %3d", reg7e.agcEnab, reg7e.gainIdx, -agcGain, reg7e.agcSigStrength, BK4819_GetRSSI());
-	UI_PrintStringSmall(buf, 2, 0, 3);
+	UI_PrintStringSmallNormal(buf, 2, 0, 3);
 	if(now)
 		ST7565_BlitLine(3);
 }
@@ -343,9 +343,9 @@ void UI_DisplayMain(void)
 			if(gScanRangeStart) {
 				UI_PrintString("ScnRng", 5, 0, line, 8);
 				sprintf(String, "%3u.%05u", gScanRangeStart / 100000, gScanRangeStart % 100000);
-				UI_PrintStringSmall(String, 56, 0, line);
+				UI_PrintStringSmallNormal(String, 56, 0, line);
 				sprintf(String, "%3u.%05u", gScanRangeStop / 100000, gScanRangeStop % 100000);
-				UI_PrintStringSmall(String, 56, 0, line + 1);
+				UI_PrintStringSmallNormal(String, 56, 0, line + 1);
 				continue;
 			}
 #endif
@@ -360,7 +360,6 @@ void UI_DisplayMain(void)
 				// show DTMF stuff
 #ifdef ENABLE_DTMF_CALLING
 				char Contact[16];
-
 				if (!gDTMF_InputMode) {
 					if (gDTMF_CallState == DTMF_CALL_STATE_CALL_OUT) {
 						pPrintStr = DTMF_FindContact(gDTMF_String, Contact) ? Contact : gDTMF_String;
@@ -421,11 +420,7 @@ void UI_DisplayMain(void)
 				if (activeTxVFO == vfo_num)
 				{	// show the TX symbol
 					mode = VFO_MODE_TX;
-#ifdef ENABLE_SMALL_BOLD
 					UI_PrintStringSmallBold("TX", 14, 0, line);
-#else
-					UI_PrintStringSmall("TX", 14, 0, line);
-#endif
 				}
 			}
 		}
@@ -433,11 +428,7 @@ void UI_DisplayMain(void)
 		{	// receiving .. show the RX symbol
 			mode = VFO_MODE_RX;
 			if (FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num) {
-#ifdef ENABLE_SMALL_BOLD
 				UI_PrintStringSmallBold("RX", 14, 0, line);
-#else
-				UI_PrintStringSmall("RX", 14, 0, line);
-#endif
 			}
 		}
 
@@ -449,7 +440,7 @@ void UI_DisplayMain(void)
 				sprintf(String, "M%u", gEeprom.ScreenChannel[vfo_num] + 1);
 			else
 				sprintf(String, "M%.3s", INPUTBOX_GetAscii());  // show the input text
-			UI_PrintStringSmall(String, x, 0, line + 1);
+			UI_PrintStringSmallNormal(String, x, 0, line + 1);
 		}
 		else if (IS_FREQ_CHANNEL(gEeprom.ScreenChannel[vfo_num]))
 		{	// frequency mode
@@ -457,7 +448,7 @@ void UI_DisplayMain(void)
 			const unsigned int x = 2;
 			char * buf = gEeprom.VfoInfo[vfo_num].pRX->Frequency < _1GHz_in_KHz ? "" : "+";
 			sprintf(String, "F%u%s", 1 + gEeprom.ScreenChannel[vfo_num] - FREQ_CHANNEL_FIRST, buf);
-			UI_PrintStringSmall(String, x, 0, line + 1);
+			UI_PrintStringSmallNormal(String, x, 0, line + 1);
 		}
 #ifdef ENABLE_NOAA
 		else
@@ -470,7 +461,7 @@ void UI_DisplayMain(void)
 			{	// user entering channel number
 				sprintf(String, "N%u%u", '0' + gInputBox[0], '0' + gInputBox[1]);
 			}
-			UI_PrintStringSmall(String, 7, 0, line + 1);
+			UI_PrintStringSmallNormal(String, 7, 0, line + 1);
 		}
 #endif
 
@@ -500,7 +491,7 @@ void UI_DisplayMain(void)
 #ifdef ENABLE_BIG_FREQ
 			if(!isGigaF) {
 				// show the remaining 2 small frequency digits
-				UI_PrintStringSmall(String + 7, 113, 0, line + 1);
+				UI_PrintStringSmallNormal(String + 7, 113, 0, line + 1);
 				String[7] = 0;
 				// show the main large frequency digits
 				UI_DisplayFrequency(String, 32, line, false);
@@ -547,7 +538,7 @@ void UI_DisplayMain(void)
 #ifdef ENABLE_BIG_FREQ
 						if(frequency < _1GHz_in_KHz) {
 							// show the remaining 2 small frequency digits
-							UI_PrintStringSmall(String + 7, 113, 0, line + 1);
+							UI_PrintStringSmallNormal(String + 7, 113, 0, line + 1);
 							String[7] = 0;
 							// show the main large frequency digits
 							UI_DisplayFrequency(String, 32, line, false);
@@ -579,14 +570,10 @@ void UI_DisplayMain(void)
 							UI_PrintString(String, 32, 0, line, 8);
 						}
 						else {
-#ifdef ENABLE_SMALL_BOLD
 							UI_PrintStringSmallBold(String, 32 + 4, 0, line);
-#else
-							UI_PrintStringSmall(String, 32 + 4, 0, line);
-#endif
 							// show the channel frequency below the channel number/name
 							sprintf(String, "%03u.%05u", frequency / 100000, frequency % 100000);
-							UI_PrintStringSmall(String, 32 + 4, 0, line + 1);
+							UI_PrintStringSmallNormal(String, 32 + 4, 0, line + 1);
 						}
 
 						break;
@@ -599,7 +586,7 @@ void UI_DisplayMain(void)
 #ifdef ENABLE_BIG_FREQ
 				if(frequency < _1GHz_in_KHz) {
 					// show the remaining 2 small frequency digits
-					UI_PrintStringSmall(String + 7, 113, 0, line + 1);
+					UI_PrintStringSmallNormal(String + 7, 113, 0, line + 1);
 					String[7] = 0;
 					// show the main large frequency digits
 					UI_DisplayFrequency(String, 32, line, false);
@@ -669,7 +656,7 @@ void UI_DisplayMain(void)
 				s = gModulationStr[mod];
 			break;
 		}
-		UI_PrintStringSmall(s, LCD_WIDTH + 24, 0, line + 1);
+		UI_PrintStringSmallNormal(s, LCD_WIDTH + 24, 0, line + 1);
 
 		if (state == VFO_STATE_NORMAL || state == VFO_STATE_ALARM)
 		{	// show the TX power
@@ -677,7 +664,7 @@ void UI_DisplayMain(void)
 			const unsigned int i = gEeprom.VfoInfo[vfo_num].OUTPUT_POWER;
 			String[0] = (i < ARRAY_SIZE(pwr_list)) ? pwr_list[i] : '\0';
 			String[1] = '\0';
-			UI_PrintStringSmall(String, LCD_WIDTH + 46, 0, line + 1);
+			UI_PrintStringSmallNormal(String, LCD_WIDTH + 46, 0, line + 1);
 		}
 
 		if (gEeprom.VfoInfo[vfo_num].freq_config_RX.Frequency != gEeprom.VfoInfo[vfo_num].freq_config_TX.Frequency)
@@ -686,12 +673,12 @@ void UI_DisplayMain(void)
 			const unsigned int i = gEeprom.VfoInfo[vfo_num].TX_OFFSET_FREQUENCY_DIRECTION;
 			String[0] = (i < sizeof(dir_list)) ? dir_list[i] : '?';
 			String[1] = '\0';
-			UI_PrintStringSmall(String, LCD_WIDTH + 54, 0, line + 1);
+			UI_PrintStringSmallNormal(String, LCD_WIDTH + 54, 0, line + 1);
 		}
 
 		// show the TX/RX reverse symbol
 		if (gEeprom.VfoInfo[vfo_num].FrequencyReverse)
-			UI_PrintStringSmall("R", LCD_WIDTH + 62, 0, line + 1);
+			UI_PrintStringSmallNormal("R", LCD_WIDTH + 62, 0, line + 1);
 
 		{	// show the narrow band symbol
 			String[0] = '\0';
@@ -700,18 +687,18 @@ void UI_DisplayMain(void)
 				String[0] = 'N';
 				String[1] = '\0';
 			}
-			UI_PrintStringSmall(String, LCD_WIDTH + 70, 0, line + 1);
+			UI_PrintStringSmallNormal(String, LCD_WIDTH + 70, 0, line + 1);
 		}
 
 #ifdef ENABLE_DTMF_CALLING
 		// show the DTMF decoding symbol
 		if (gEeprom.VfoInfo[vfo_num].DTMF_DECODING_ENABLE || gSetting_KILLED)
-			UI_PrintStringSmall("DTMF", LCD_WIDTH + 78, 0, line + 1);
+			UI_PrintStringSmallNormal("DTMF", LCD_WIDTH + 78, 0, line + 1);
 #endif
 
 		// show the audio scramble symbol
 		if (gEeprom.VfoInfo[vfo_num].SCRAMBLING_TYPE > 0 && gSetting_ScrambleEnable)
-			UI_PrintStringSmall("SCR", LCD_WIDTH + 106, 0, line + 1);
+			UI_PrintStringSmallNormal("SCR", LCD_WIDTH + 106, 0, line + 1);
 	}
 
 #ifdef ENABLE_AGC_SHOW_DATA
@@ -744,7 +731,7 @@ void UI_DisplayMain(void)
 
 			center_line = CENTER_LINE_AM_FIX_DATA;
 			AM_fix_print_data(gEeprom.RX_VFO, String);
-			UI_PrintStringSmall(String, 2, 0, 3);
+			UI_PrintStringSmallNormal(String, 2, 0, 3);
 		}
 		else
 #endif
@@ -774,7 +761,7 @@ void UI_DisplayMain(void)
 					center_line = CENTER_LINE_DTMF_DEC;
 
 					sprintf(String, "DTMF %s", gDTMF_RX_live + idx);
-					UI_PrintStringSmall(String, 2, 0, 3);
+					UI_PrintStringSmallNormal(String, 2, 0, 3);
 				}
 			#else
 				if (gSetting_live_DTMF_decoder && gDTMF_RX_index > 0)
@@ -789,7 +776,7 @@ void UI_DisplayMain(void)
 					center_line = CENTER_LINE_DTMF_DEC;
 
 					sprintf(String, "DTMF %s", gDTMF_RX_live + idx);
-					UI_PrintStringSmall(String, 2, 0, 3);
+					UI_PrintStringSmallNormal(String, 2, 0, 3);
 				}
 			#endif
 
@@ -808,7 +795,7 @@ void UI_DisplayMain(void)
 				sprintf(String, "Charge %u.%02uV %u%%",
 					gBatteryVoltageAverage / 100, gBatteryVoltageAverage % 100,
 					BATTERY_VoltsToPercent(gBatteryVoltageAverage));
-				UI_PrintStringSmall(String, 2, 0, 3);
+				UI_PrintStringSmallNormal(String, 2, 0, 3);
 			}
 #endif
 		}

--- a/ui/main.c
+++ b/ui/main.c
@@ -773,8 +773,7 @@ void UI_DisplayMain(void)
 
 					center_line = CENTER_LINE_DTMF_DEC;
 
-					strcpy(String, "DTMF ");
-					strcat(String, gDTMF_RX_live + idx);
+					sprintf(String, "DTMF %s", gDTMF_RX_live + idx);
 					UI_PrintStringSmall(String, 2, 0, 3);
 				}
 			#else
@@ -789,8 +788,7 @@ void UI_DisplayMain(void)
 
 					center_line = CENTER_LINE_DTMF_DEC;
 
-					strcpy(String, "DTMF ");
-					strcat(String, gDTMF_RX + idx);
+					sprintf(String, "DTMF %s", gDTMF_RX_live + idx);
 					UI_PrintStringSmall(String, 2, 0, 3);
 				}
 			#endif

--- a/ui/main.c
+++ b/ui/main.c
@@ -309,7 +309,7 @@ void UI_DisplayMain(void)
 	center_line = CENTER_LINE_NONE;
 
 	// clear the screen
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	UI_DisplayClear();
 
 	if(gLowBattery && !gLowBatteryConfirmed) {
 		UI_DisplayPopup("LOW BATTERY");

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -15,26 +15,27 @@
  */
 
 #include <string.h>
-#include <stdlib.h>  // abs()
+#include <stdlib.h>
 
-#include "app/dtmf.h"
-#include "app/menu.h"
-#include "bitmaps.h"
-#include "board.h"
-#include "dcs.h"
-#include "driver/backlight.h"
-#include "driver/bk4819.h"
-#include "driver/eeprom.h"   // EEPROM_ReadBuffer()
-#include "driver/st7565.h"
-#include "external/printf/printf.h"
-#include "frequencies.h"
-#include "helper/battery.h"
-#include "misc.h"
-#include "settings.h"
-#include "ui/helper.h"
-#include "ui/inputbox.h"
-#include "ui/menu.h"
-#include "ui/ui.h"
+#include "../app/dtmf.h"
+#include "../app/menu.h"
+#include "../bitmaps.h"
+#include "../board.h"
+#include "../dcs.h"
+#include "../driver/backlight.h"
+#include "../driver/bk4819.h"
+#include "../driver/eeprom.h"
+#include "../driver/st7565.h"
+#include "../external/printf/printf.h"
+#include "../frequencies.h"
+#include "../helper/battery.h"
+#include "../misc.h"
+#include "../settings.h"
+#include "helper.h"
+#include "inputbox.h"
+#include "menu.h"
+#include "ui.h"
+
 
 const t_menu_item MenuList[] =
 {
@@ -56,7 +57,7 @@ const t_menu_item MenuList[] =
 	{"ScAdd2", VOICE_ID_INVALID,                       MENU_S_ADD2        },
 	{"ChSave", VOICE_ID_MEMORY_CHANNEL,                MENU_MEM_CH        }, // was "MEM-CH"
 	{"ChDele", VOICE_ID_DELETE_CHANNEL,                MENU_DEL_CH        }, // was "DEL-CH"
-	{"ChName", VOICE_ID_INVALID,                       MENU_MEM_NAME      },	
+	{"ChName", VOICE_ID_INVALID,                       MENU_MEM_NAME      },
 
 	{"SList",  VOICE_ID_INVALID,                       MENU_S_LIST        },
 	{"SList1", VOICE_ID_INVALID,                       MENU_SLIST1        },
@@ -78,10 +79,10 @@ const t_menu_item MenuList[] =
 	{"Mic",    VOICE_ID_INVALID,                       MENU_MIC           },
 #ifdef ENABLE_AUDIO_BAR
 	{"MicBar", VOICE_ID_INVALID,                       MENU_MIC_BAR       },
-#endif		
+#endif
 	{"ChDisp", VOICE_ID_INVALID,                       MENU_MDF           }, // was "MDF"
 	{"POnMsg", VOICE_ID_INVALID,                       MENU_PONMSG        },
-	{"BatTxt", VOICE_ID_INVALID,                       MENU_BAT_TXT       },	
+	{"BatTxt", VOICE_ID_INVALID,                       MENU_BAT_TXT       },
 	{"BackLt", VOICE_ID_INVALID,                       MENU_ABR           }, // was "ABR"
 	{"BLMin",  VOICE_ID_INVALID,                       MENU_ABR_MIN       },
 	{"BLMax",  VOICE_ID_INVALID,                       MENU_ABR_MAX       },
@@ -346,13 +347,13 @@ const t_sidefunction gSubMenu_SIDEFUNCTIONS[] =
 #ifdef ENABLE_VOX
 	{"VOX",				ACTION_OPT_VOX},
 #endif
-#ifdef ENABLE_ALARM	
+#ifdef ENABLE_ALARM
 	{"ALARM",			ACTION_OPT_ALARM},
 #endif
 #ifdef ENABLE_FMRADIO
 	{"FM RADIO",		ACTION_OPT_FM},
-#endif	
-#ifdef ENABLE_TX1750	
+#endif
+#ifdef ENABLE_TX1750
 	{"1750HZ",			ACTION_OPT_1750},
 #endif
 	{"LOCK\nKEYPAD",	ACTION_OPT_KEYLOCK},
@@ -601,7 +602,7 @@ void UI_DisplayMenu(void)
 				BACKLIGHT_SetBrightness(gSubMenuSelection);
 			else if(BACKLIGHT_GetBrightness() < 4)
 				BACKLIGHT_SetBrightness(4);
-			break;	
+			break;
 
 		case MENU_AM:
 			strcpy(String, gModulationStr[gSubMenuSelection]);
@@ -838,7 +839,7 @@ void UI_DisplayMenu(void)
 
 		case MENU_BATTYP:
 			strcpy(String, gSubMenu_BATTYP[gSubMenuSelection]);
-			break;	
+			break;
 
 		case MENU_F1SHRT:
 		case MENU_F1LONG:
@@ -981,7 +982,7 @@ void UI_DisplayMenu(void)
 	    UI_MENU_GetCurrentMenuId() == MENU_T_DCS
 #ifdef ENABLE_DTMF_CALLING
 	    || UI_MENU_GetCurrentMenuId() == MENU_D_LIST
-#endif		
+#endif
 		)
 
 	{

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -404,7 +404,7 @@ void UI_DisplayMenu(void)
 #endif
 
 	// clear the screen buffer
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	UI_DisplayClear();
 
 	#if 0
 		// original menu layout

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -66,7 +66,6 @@ const t_menu_item MenuList[] =
 #ifdef ENABLE_NOAA
 	{"NOAA-S", VOICE_ID_INVALID,                       MENU_NOAA_S        },
 #endif
-
 	{"F1Shrt",    VOICE_ID_INVALID,                    MENU_F1SHRT        },
 	{"F1Long",    VOICE_ID_INVALID,                    MENU_F1LONG        },
 	{"F2Shrt",    VOICE_ID_INVALID,                    MENU_F2SHRT        },
@@ -372,8 +371,8 @@ uint8_t gMenuCursor;
 int UI_MENU_GetCurrentMenuId() {
 	if(gMenuCursor < ARRAY_SIZE(MenuList))
 		return MenuList[gMenuCursor].menu_id;
-	else
-		return MenuList[ARRAY_SIZE(MenuList)-1].menu_id;
+
+	return MenuList[ARRAY_SIZE(MenuList)-1].menu_id;
 }
 
 uint8_t UI_MENU_GetMenuIdx(uint8_t id)
@@ -403,7 +402,6 @@ void UI_DisplayMenu(void)
 	char               Contact[16];
 #endif
 
-	// clear the screen buffer
 	UI_DisplayClear();
 
 	#if 0
@@ -431,7 +429,8 @@ void UI_DisplayMenu(void)
 
 		// draw the menu index number/count
 		sprintf(String, "%2u.%u", 1 + gMenuCursor, gMenuListCount);
-		UI_PrintStringSmall(String, 2, 0, 6);
+
+		UI_PrintStringSmallNormal(String, 2, 0, 6);
 
 	#else
 	{	// new menu layout .. experimental & unfinished
@@ -445,10 +444,10 @@ void UI_DisplayMenu(void)
 			{	// leading menu items - small text
 				const int k = menu_index + i - 2;
 				if (k < 0)
-					UI_PrintStringSmall(MenuList[gMenuListCount + k].name, 0, 0, i);  // wrap-a-round
+					UI_PrintStringSmallNormal(MenuList[gMenuListCount + k].name, 0, 0, i);  // wrap-a-round
 				else
 				if (k >= 0 && k < (int)gMenuListCount)
-					UI_PrintStringSmall(MenuList[k].name, 0, 0, i);
+					UI_PrintStringSmallNormal(MenuList[k].name, 0, 0, i);
 				i++;
 			}
 
@@ -461,23 +460,23 @@ void UI_DisplayMenu(void)
 			{	// trailing menu item - small text
 				const int k = menu_index + i - 2;
 				if (k >= 0 && k < (int)gMenuListCount)
-					UI_PrintStringSmall(MenuList[k].name, 0, 0, 1 + i);
+					UI_PrintStringSmallNormal(MenuList[k].name, 0, 0, 1 + i);
 				else
 				if (k >= (int)gMenuListCount)
-					UI_PrintStringSmall(MenuList[gMenuListCount - k].name, 0, 0, 1 + i);  // wrap-a-round
+					UI_PrintStringSmallNormal(MenuList[gMenuListCount - k].name, 0, 0, 1 + i);  // wrap-a-round
 				i++;
 			}
 
 			// draw the menu index number/count
 			sprintf(String, "%2u.%u", 1 + gMenuCursor, gMenuListCount);
-			UI_PrintStringSmall(String, 2, 0, 6);
+			UI_PrintStringSmallNormal(String, 2, 0, 6);
 		}
 		else
 		if (menu_index >= 0 && menu_index < (int)gMenuListCount)
 		{	// current menu item
 //			strcat(String, ":");
 			UI_PrintString(MenuList[menu_index].name, 0, 0, 0, 8);
-//			UI_PrintStringSmall(String, 0, 0, 0);
+//			UI_PrintStringSmallNormal(String, 0, 0, 0);
 		}
 	}
 	#endif
@@ -883,7 +882,7 @@ void UI_DisplayMenu(void)
 			for (i = 0; i < len && lines > 0; lines--)
 			{
 				if (small)
-					UI_PrintStringSmall(String + i, menu_item_x1, menu_item_x2, y);
+					UI_PrintStringSmallNormal(String + i, menu_item_x1, menu_item_x2, y);
 				else
 					UI_PrintString(String + i, menu_item_x1, menu_item_x2, y, 8);
 
@@ -922,7 +921,7 @@ void UI_DisplayMenu(void)
 		if (gSubMenuSelection < 0 || !gEeprom.SCAN_LIST_ENABLED[i]) {
 			UI_PrintString(pPrintStr, menu_item_x1, menu_item_x2, 2, 8);
 		} else {
-			UI_PrintStringSmall(pPrintStr, menu_item_x1, menu_item_x2, 2);
+			UI_PrintStringSmallNormal(pPrintStr, menu_item_x1, menu_item_x2, 2);
 
 			if (IS_MR_CHANNEL(gEeprom.SCANLIST_PRIORITY_CH1[i])) {
 				sprintf(String, "PRI%d:%u", 1, gEeprom.SCANLIST_PRIORITY_CH1[i] + 1);
@@ -967,7 +966,7 @@ void UI_DisplayMenu(void)
 #endif
 	) {
 		sprintf(String, "%2d", gSubMenuSelection);
-		UI_PrintStringSmall(String, 105, 0, 0);
+		UI_PrintStringSmallNormal(String, 105, 0, 0);
 	}
 
 	if ((UI_MENU_GetCurrentMenuId() == MENU_RESET    ||

--- a/ui/scanner.c
+++ b/ui/scanner.c
@@ -31,7 +31,7 @@ void UI_DisplayScanner(void)
 	bool bCentered;
 	uint8_t Start;
 
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	UI_DisplayClear();
 
 	if (gScanSingleFrequency || (gScanCssState != SCAN_CSS_STATE_OFF && gScanCssState != SCAN_CSS_STATE_FAILED)) {
 		sprintf(String, "FREQ:%u.%05u", gScanFrequency / 100000, gScanFrequency % 100000);

--- a/ui/scanner.c
+++ b/ui/scanner.c
@@ -26,56 +26,58 @@
 
 void UI_DisplayScanner(void)
 {
-	char    String[16];
-	bool    bCentered;
+	char  String[16] = {0};
+	char *pPrintStr = String;
+	bool bCentered;
 	uint8_t Start;
 
 	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
 
-	memset(String, 0, sizeof(String));
-	if (gScanSingleFrequency || (gScanCssState != SCAN_CSS_STATE_OFF && gScanCssState != SCAN_CSS_STATE_FAILED))
+	if (gScanSingleFrequency || (gScanCssState != SCAN_CSS_STATE_OFF && gScanCssState != SCAN_CSS_STATE_FAILED)) {
 		sprintf(String, "FREQ:%u.%05u", gScanFrequency / 100000, gScanFrequency % 100000);
-	else
-		strcpy(String, "FREQ:**.*****");
-	UI_PrintString(String, 2, 0, 1, 8);
+		pPrintStr = String;
+	} else {
+		pPrintStr = "FREQ:**.*****";
+	}
 
-	memset(String, 0, sizeof(String));
-	if (gScanCssState < SCAN_CSS_STATE_FOUND || !gScanUseCssResult)
-		strcpy(String, "CTC:******");
-	else
-	if (gScanCssResultType == CODE_TYPE_CONTINUOUS_TONE)
+	UI_PrintString(pPrintStr, 2, 0, 1, 8);
+
+	if (gScanCssState < SCAN_CSS_STATE_FOUND || !gScanUseCssResult) {
+		pPrintStr = "CTC:******";
+	} else if (gScanCssResultType == CODE_TYPE_CONTINUOUS_TONE) {
 		sprintf(String, "CTC:%u.%uHz", CTCSS_Options[gScanCssResultCode] / 10, CTCSS_Options[gScanCssResultCode] % 10);
-	else
+		pPrintStr = String;
+	} else {
 		sprintf(String, "DCS:D%03oN", DCS_Options[gScanCssResultCode]);
-	UI_PrintString(String, 2, 0, 3, 8);
+		pPrintStr = String;
+	}
 
+	UI_PrintString(pPrintStr, 2, 0, 3, 8);
 	memset(String, 0, sizeof(String));
-	if (gScannerSaveState == SCAN_SAVE_CHANNEL)
-	{
-		strcpy(String, "SAVE?");
-
+	if (gScannerSaveState == SCAN_SAVE_CHANNEL) {
+		pPrintStr = "SAVE?";
 		Start     = 0;
 		bCentered = 1;
-	}
-	else
-	{
+	} else {
+		Start     = 2;
+		bCentered = 0;
+
 		if (gScannerSaveState == SCAN_SAVE_CHAN_SEL) {
 			strcpy(String, "SAVE:");
 			UI_GenerateChannelStringEx(String + 5, gShowChPrefix, gScanChannel);
-		}
-		else if (gScanCssState < SCAN_CSS_STATE_FOUND) {
+			pPrintStr = String;
+		} else if (gScanCssState < SCAN_CSS_STATE_FOUND) {
 			strcpy(String, "SCAN");
 			memset(String + 4, '.', (gScanProgressIndicator & 7) + 1);
+			pPrintStr = String;
+		} else if (gScanCssState == SCAN_CSS_STATE_FOUND) {
+			pPrintStr = "SCAN CMP.";
+		} else {
+			pPrintStr = "SCAN FAIL.";
 		}
-		else if (gScanCssState == SCAN_CSS_STATE_FOUND)
-			strcpy(String, "SCAN CMP.");
-		else
-			strcpy(String, "SCAN FAIL.");
-
-		Start     = 2;
-		bCentered = 0;
 	}
-	UI_PrintString(String, Start, bCentered ? 127 : 0, 5, 8);
-	
+
+	UI_PrintString(pPrintStr, Start, bCentered ? 127 : 0, 5, 8);
+
 	ST7565_BlitFullScreen();
 }

--- a/ui/status.c
+++ b/ui/status.c
@@ -36,7 +36,7 @@
 
 void UI_DisplayStatus()
 {
-	gUpdateStatus = false;	
+	gUpdateStatus = false;
 	memset(gStatusLine, 0, sizeof(gStatusLine));
 
 	uint8_t     *line = gStatusLine;
@@ -69,7 +69,7 @@ void UI_DisplayStatus()
 		memset(line + x, 0xFF, 10);
 		x1 = x + 10;
 	}
-	else 
+	else
 #endif
 #ifdef ENABLE_FMRADIO
 	if (gFmRadioMode) { // FM indicator
@@ -91,7 +91,7 @@ void UI_DisplayStatus()
 			else {	// frequency mode
 				s = "S";
 			}
-			UI_PrintStringSmallBuffer(s, line + x + 1);
+			UI_PrintStringSmallBufferNormal(s, line + x + 1);
 			x1 = x + 10;
 		}
 	}
@@ -109,9 +109,9 @@ void UI_DisplayStatus()
 	if(!SCANNER_IsScanning()) {
 		uint8_t dw = (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF) + (gEeprom.CROSS_BAND_RX_TX != CROSS_BAND_OFF) * 2;
 		if(dw == 1 || dw == 3) { // DWR - dual watch + respond
-			if(gDualWatchActive) 
+			if(gDualWatchActive)
 				memcpy(line + x + (dw==1?0:2), BITMAP_TDR1, sizeof(BITMAP_TDR1) - (dw==1?0:5));
-			else 
+			else
 				memcpy(line + x + 3, BITMAP_TDR2, sizeof(BITMAP_TDR2));
 		}
 		else if(dw == 2) { // XB - crossband
@@ -119,7 +119,7 @@ void UI_DisplayStatus()
 		}
 	}
 	x += sizeof(BITMAP_TDR1) + 1;
-	
+
 #ifdef ENABLE_VOX
 	// VOX indicator
 	if (gEeprom.VOX_SWITCH) {
@@ -144,7 +144,7 @@ void UI_DisplayStatus()
 	}
 
 	{	// battery voltage or percentage
-		char         s[8] = "";	
+		char         s[8] = "";
 		unsigned int x2 = LCD_WIDTH - sizeof(BITMAP_BatteryLevel1) - 0;
 
 		if (gChargingWithTypeC)
@@ -154,13 +154,13 @@ void UI_DisplayStatus()
 			default:
 			case 0:
 				break;
-	
+
 			case 1:	{	// voltage
 				const uint16_t voltage = (gBatteryVoltageAverage <= 999) ? gBatteryVoltageAverage : 999; // limit to 9.99V
 				sprintf(s, "%u.%02uV", voltage / 100, voltage % 100);
 				break;
 			}
-			
+
 			case 2:		// percentage
 				sprintf(s, "%u%%", BATTERY_VoltsToPercent(gBatteryVoltageAverage));
 				break;
@@ -168,12 +168,12 @@ void UI_DisplayStatus()
 
 		unsigned int space_needed = (7 * strlen(s));
 		if (x2 >= (x1 + space_needed))
-			UI_PrintStringSmallBuffer(s, line + x2 - space_needed);
+			UI_PrintStringSmallBufferNormal(s, line + x2 - space_needed);
 	}
-		
+
 	// move to right side of the screen
 	x = LCD_WIDTH - sizeof(BITMAP_BatteryLevel1) - sizeof(BITMAP_USB_C);
-	
+
 	// USB-C charge indicator
 	if (gChargingWithTypeC)
 		memcpy(line + x, BITMAP_USB_C, sizeof(BITMAP_USB_C));
@@ -181,7 +181,7 @@ void UI_DisplayStatus()
 
 	// BATTERY LEVEL indicator
 	UI_DrawBattery(line + x, gBatteryDisplayLevel, gLowBatteryBlink);
-	
+
 	// **************
 
 	ST7565_BlitStatusLine();

--- a/ui/welcome.c
+++ b/ui/welcome.c
@@ -47,17 +47,9 @@ void UI_DisplayWelcome(void)
 	memset(gStatusLine,  0, sizeof(gStatusLine));
 	UI_DisplayClear();
 
-	if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_NONE)
-	{
+	if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_NONE || gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_FULL_SCREEN) {
 		ST7565_FillScreen(0xFF);
-	}
-	else
-	if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_FULL_SCREEN)
-	{
-		ST7565_FillScreen(0xFF);
-	}
-	else
-	{
+	} else {
 		memset(WelcomeString0, 0, sizeof(WelcomeString0));
 		memset(WelcomeString1, 0, sizeof(WelcomeString1));
 
@@ -77,7 +69,7 @@ void UI_DisplayWelcome(void)
 
 		UI_PrintString(WelcomeString0, 0, 127, 0, 10);
 		UI_PrintString(WelcomeString1, 0, 127, 2, 10);
-		UI_PrintStringSmall(Version, 0, 128, 6);
+		UI_PrintStringSmallNormal(Version, 0, 128, 6);
 
 		ST7565_BlitStatusLine();  // blank status line
 		ST7565_BlitFullScreen();

--- a/ui/welcome.c
+++ b/ui/welcome.c
@@ -30,7 +30,7 @@
 void UI_DisplayReleaseKeys(void)
 {
 	memset(gStatusLine,  0, sizeof(gStatusLine));
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	UI_DisplayClear();
 
 	UI_PrintString("RELEASE", 0, 127, 1, 10);
 	UI_PrintString("ALL KEYS", 0, 127, 3, 10);
@@ -43,9 +43,9 @@ void UI_DisplayWelcome(void)
 {
 	char WelcomeString0[16];
 	char WelcomeString1[16];
-	
+
 	memset(gStatusLine,  0, sizeof(gStatusLine));
-	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	UI_DisplayClear();
 
 	if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_NONE)
 	{
@@ -83,4 +83,3 @@ void UI_DisplayWelcome(void)
 		ST7565_BlitFullScreen();
 	}
 }
-


### PR DESCRIPTION
The most relevant change is that PrintStringSmallBold always exists but will behave as PrintStringSmallNormal if boldface is not enabled, thus limiting the code that should be guarded.

Reduces binary size from 60760 (@ ab61c4e74fda)  to 60220