### PR TITLE
Add ifdef preprocessor directives if ENABLE_DTMF_CALLING is disable

### DIFF
--- a/app/menu.c
+++ b/app/menu.c
@@ -1404,8 +1404,11 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 			if (UI_MENU_GetCurrentMenuId() != MENU_SCR)
 				gAnotherVoiceID = MenuList[gMenuCursor].voice_id;
 		#endif
-        if (UI_MENU_GetCurrentMenuId() == MENU_ANI_ID || UI_MENU_GetCurrentMenuId() == MENU_UPCODE|| UI_MENU_GetCurrentMenuId() == MENU_DWCODE)
-            return;
+        #ifdef ENABLE_DTMF_CALLING
+            if (UI_MENU_GetCurrentMenuId() == MENU_ANI_ID || UI_MENU_GetCurrentMenuId() == MENU_UPCODE|| UI_MENU_GetCurrentMenuId() == MENU_DWCODE)
+        #else
+            if (UI_MENU_GetCurrentMenuId() == MENU_UPCODE|| UI_MENU_GetCurrentMenuId() == MENU_DWCODE)
+        #endif
 		#if 1
 			if (UI_MENU_GetCurrentMenuId() == MENU_DEL_CH || UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME)
 				if (!RADIO_CheckValidChannel(gSubMenuSelection, false, 0))


### PR DESCRIPTION
If ENABLE_DTMF_CALLING is disable in the Makefile, compilation failed.

```
app/menu.c: In function 'MENU_Key_MENU':
app/menu.c:1407:43: error: 'MENU_ANI_ID' undeclared (first use in this function); did you mean 'MENU_PTT_ID'?
 1407 |         if (UI_MENU_GetCurrentMenuId() == MENU_ANI_ID || UI_MENU_GetCurrentMenuId() == MENU_UPCODE|| UI_MENU_GetCurrentMenuId() == MENU_DWCODE)
      |                                           ^~~~~~~~~~~
      |                                           MENU_PTT_ID
app/menu.c:1407:43: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:446: app/menu.o] Error 1
```

So I propose to add ifdef preprocessor directives.
Thank you for your work and 73' de F4HWN.
