### PR TITLE
spectrum: The dbMax range is more stringent

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -475,7 +475,7 @@ static void UpdateRssiTriggerLevel(bool inc) {
 static void UpdateDBMax(bool inc) {
   if (inc && settings.dbMax < 10) {
     settings.dbMax += 1;
-  } else if (!inc && settings.dbMax > settings.dbMin) {
+  } else if (!inc && settings.dbMax > 12+settings.dbMin) {
     settings.dbMax -= 1;
   } else {
     return;


### PR DESCRIPTION
If we want the dbMax value to always be greater than dbMin, there should be at least a '+1'.