### PR TITLE
Optimized Dockerfile

### DIFF
--- a/Dockerfile.egzumer
+++ b/Dockerfile.egzumer
@@ -1,0 +1,4 @@
+FROM archlinux:latest
+RUN pacman -Syyu make git which arm-none-eabi-gcc arm-none-eabi-newlib python-crcmod --noconfirm
+RUN mkdir -p /app && chmod 777 /app
+WORKDIR /app

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -1,3 +1,5 @@
-#!/bin/sh
-docker build -t uvk5 .
-docker run --rm -v ${PWD}/compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware* compiled-firmware/"
+#!/bin/env sh
+mkdir -p compiled-firmware
+docker build -t egzumer -f Dockerfile.egzumer .
+docker run --rm --user `id -u`:`id -g` -v `pwd`:/app egzumer \
+/bin/bash -c 'make && mv firmware firmware.bin firmware.packed.bin compiled-firmware && chmod -R 644 compiled-firmware/*'


### PR DESCRIPTION
This creates a new Dockerfile to be used with the `compile-with-docker.sh` script.

The original Dockerfile copies code into the container and creates compiled firmware owned by root. This one mounts the repo as a volume under `/app`. The compilation step is run by the current userid instead of root. The resultant artifacts are correctly chmodded to 644, as they are not executables. The stray copy of `firmware.ld` that shows up in `compiled-firmware` is now omitted. This Dockerfile brings in fewer dependencies, in my case decreasing the size of the build container from 4.24GB to 3.75GB.

The same approach could likely be taken with `compile-with-docker.bat`, but I don't have a Windows system here for development.

Fixes https://github.com/egzumer/uv-k5-firmware-custom/issues/576