### PR TITLE
FM: avoid saving to channel 21 and overflowing heap

### DIFF
--- a/app/fm.c
+++ b/app/fm.c
@@ -573,6 +573,7 @@ void FM_Play(void)
 			gFM_Channels[gFM_ChannelPosition++] = gEeprom.FM_FrequencyPlaying;
 
 		if (gFM_ChannelPosition >= 20) {
+			gFM_ChannelPosition--;
 			FM_PlayAndUpdate();
 			GUI_SelectNextDisplay(DISPLAY_FM);
 			return;


### PR DESCRIPTION
After FM autoscan, if all 20 stations were found, channel position is set to channel 21. Switching to VFO mode and pressing M button will result in saving to channel 21, which overflows channel array.