### PR TITLE
Fix Power On Password input

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -41,6 +41,7 @@
 #include "settings.h"
 #include "ui/inputbox.h"
 #include "ui/ui.h"
+#include "ui/lock.h"
 #include <stdlib.h>
 
 void toggle_chan_scanlist(void)
@@ -284,6 +285,13 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;  // beep when key is pressed
 		return;                                 // don't use the key till it's released
 	}
+
+	#ifdef ENABLE_PWRON_PASSWORD
+	if(gLockWasActive) {
+		gLockWasActive = false;
+		return;
+	}
+	#endif
 
 	if (!gWasFKeyPressed) { // F-key wasn't pressed
 		const uint8_t Vfo = gEeprom.TX_VFO;

--- a/ui/lock.c
+++ b/ui/lock.c
@@ -29,6 +29,8 @@
 #include "ui/inputbox.h"
 #include "ui/lock.h"
 
+bool gLockWasActive;
+
 static void Render(void)
 {
 	unsigned int i;
@@ -49,6 +51,8 @@ static void Render(void)
 
 void UI_DisplayLock(void)
 {
+	gLockWasActive = true;
+
 	KEY_Code_t  Key;
 	BEEP_Type_t Beep;
 

--- a/ui/lock.h
+++ b/ui/lock.h
@@ -19,6 +19,8 @@
 
 #ifdef ENABLE_PWRON_PASSWORD
 	void UI_DisplayLock(void);
+
+	extern bool gLockWasActive;
 #endif
 
 #endif


### PR DESCRIPTION
Fixes an issue where the last keypress of the power-on password would also be handled by the main interface, leading to an unwanted VFO/MR input on every boot.